### PR TITLE
feat: more directives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ leptos-mview-macro = { path = "leptos-mview-macro", version = "0.1.0" }
 
 [dev-dependencies]
 trybuild = "1"
-leptos = { version = "0.5.1", features = ["nightly", "csr"] }
+leptos = { version = "0.5.2", features = ["nightly", "csr"] }
 
 [workspace]
 members = ["leptos-mview-core", "leptos-mview-macro"]

--- a/README.md
+++ b/README.md
@@ -275,15 +275,16 @@ See also: [boolean attributes on HTML elements](#boolean-attributes-on-html-elem
 
 #### Directives
 
-Some special attributes (distinguished by the `:`) called **directives** have special functionality. Most have the same behaviour as Leptos. These include:
+Some special attributes (distinguished by the `:`) called **directives** have special functionality. All have the same behaviour as Leptos. These include:
 - `class:class-name=[when to show]`
 - `style:style-key=[style value]`
 - `on:event={move |ev| event handler}`
 - `prop:property-name={signal}`
 - `attr:name={value}`
-- `clone:{ident_to_clone}`: This differs slightly from Leptos, which just has `clone:ident_to_clone`. See [clone directive](#clone-directive) for more details - tldr: just use `clone:{ident_to_clone}`.
+- `clone:ident_to_clone`
+- `use:directive_name` or `use:directive_name={params}`
 
-All of these directives also support the attribute shorthand:
+All of these directives except `clone` also support the attribute shorthand:
 ```rust
 let color = create_rw_signal("red".to_string());
 let disabled = false;
@@ -351,25 +352,6 @@ use leptos::*;
 use leptos_mview::view;
 let boolean_signal = create_rw_signal(true);
 view! { input type="checkbox" checked=[boolean_signal().to_string()]; }
-```
-
-### Clone directive
-
-The clone directive follows the same syntrax as all other directives, `clone:ident_to_clone={cloned_name}`. The `ident_to_clone` is the variable you are cloning, and `cloned_name` is how you can access the cloned value within the children.
-
-Inside the component's children, trying to access `ident_to_clone` wouldn't work anyways. The variable is usually shadowed (which Leptos does with just `clone:ident_to_clone`), which can be done in this macro with `clone:{ident_to_clone}`.
-
-```rust
-#[component] fn Owning(children: ChildrenFn) -> impl IntoView { children }
-
-let not_copy = String::new();
-view! {
-    Owning {
-        Owning clone:{not_copy} {
-            {not_copy.clone()}
-        }
-    }
-}
 ```
 
 ## Contributing

--- a/leptos-mview-core/src/attribute.rs
+++ b/leptos-mview-core/src/attribute.rs
@@ -7,7 +7,7 @@ pub mod spread_attrs;
 use std::ops::Deref;
 
 use proc_macro2::Span;
-use syn::{parse::Parse, Token};
+use syn::{ext::IdentExt, parse::Parse, Token};
 
 use self::{directive::DirectiveAttr, kv::KvAttr, spread_attrs::SpreadAttr};
 use crate::error_ext::ResultExt;
@@ -34,7 +34,7 @@ impl Parse for Attr {
         // ident then colon must be directive
         // just ident must be regular kv attribute
         // otherwise, try kv or spread
-        if input.peek(syn::Ident) && input.peek2(Token![:]) {
+        if input.peek(syn::Ident::peek_any) && input.peek2(Token![:]) {
             let dir = input.parse::<DirectiveAttr>().unwrap_or_abort();
             Ok(Self::Directive(dir))
         } else if input.peek(syn::Ident) {

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -288,9 +288,9 @@ pub fn component_to_tokens(element: &Element) -> Option<TokenStream> {
                 #children
                 .build()
                 #dyn_attrs
-                #(#use_directives)*
-        )
+            )
         .into_view()
+        #(#use_directives)*
         #event_listeners
     })
 }

--- a/leptos-mview-core/src/value.rs
+++ b/leptos-mview-core/src/value.rs
@@ -50,18 +50,6 @@ impl ToTokens for Value {
 }
 
 impl Value {
-    /// Tries to convert a `Value` into a single ident.
-    ///
-    /// Example: the value `{something}` becomes the ident `something`.
-    ///
-    /// Returns `None` if the block does not only contain an ident.
-    pub fn as_block_with_ident(&self) -> Option<syn::Ident> {
-        let Self::Block(inner, _) = self else {
-            return None;
-        };
-        syn::parse2::<syn::Ident>(inner.clone()).ok()
-    }
-
     pub fn span(&self) -> Span {
         match self {
             Self::Lit(lit) => lit.span(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,15 +308,16 @@ See also: [boolean attributes on HTML elements](#boolean-attributes-on-html-elem
 
 #### Directives
 
-Some special attributes (distinguished by the `:`) called **directives** have special functionality. Most have the same behaviour as Leptos. These include:
+Some special attributes (distinguished by the `:`) called **directives** have special functionality. All have the same behaviour as Leptos. These include:
 - `class:class-name=[when to show]`
 - `style:style-key=[style value]`
 - `on:event={move |ev| event handler}`
 - `prop:property-name={signal}`
 - `attr:name={value}`
-- `clone:{ident_to_clone}`: This differs slightly from Leptos, which just has `clone:ident_to_clone`. See [clone directive](#clone-directive) for more details - tldr: just use `clone:{ident_to_clone}`.
+- `clone:ident_to_clone`
+- `use:directive_name` or `use:directive_name={params}`
 
-All of these directives also support the attribute shorthand:
+All of these directives except `clone` also support the attribute shorthand:
 ```
 # use leptos::*; use leptos_mview::view;
 let color = create_rw_signal("red".to_string());
@@ -397,27 +398,6 @@ use leptos::*;
 use leptos_mview::view;
 let boolean_signal = create_rw_signal(true);
 view! { input type="checkbox" checked=[boolean_signal().to_string()]; }
-# ;
-```
-
-### Clone directive
-
-The clone directive follows the same syntrax as all other directives, `clone:ident_to_clone={cloned_name}`. The `ident_to_clone` is the variable you are cloning, and `cloned_name` is how you can access the cloned value within the children.
-
-Inside the component's children, trying to access `ident_to_clone` wouldn't work anyways. The variable is usually shadowed (which Leptos does with just `clone:ident_to_clone`), which can be done in this macro with `clone:{ident_to_clone}`.
-
-```
-# use leptos::*; use leptos_mview::view;
-#[component] fn Owning(children: ChildrenFn) -> impl IntoView { children }
-
-let not_copy = String::new();
-view! {
-    Owning {
-        Owning clone:not_copy {
-            {not_copy.clone()}
-        }
-    }
-}
 # ;
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ Inside the component's children, trying to access `ident_to_clone` wouldn't work
 let not_copy = String::new();
 view! {
     Owning {
-        Owning clone:{not_copy} {
+        Owning clone:not_copy {
             {not_copy.clone()}
         }
     }

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -13,7 +13,7 @@ fn clones() {
     let notcopy = String::new();
     _ = view! {
         Owning {
-            Owning clone:{notcopy} {
+            Owning clone:notcopy {
                 {notcopy.clone()}
             }
         }
@@ -34,7 +34,7 @@ fn children_args() {
     _ = view! {
         Await
             future={move || async {"hi".to_string()}}
-            clone:{name}
+            clone:name
         |greeting| {
             {greeting} " " {name.clone()}
         }

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -22,7 +22,7 @@ fn single_element() {
             "hi"
         }
     };
-    check_str(result, r#"<div data-hk="0-0-1">hi</div>"#);
+    check_str(result, r#"<div data-hk="0-0-0-1">hi</div>"#);
 }
 
 #[test]
@@ -48,11 +48,12 @@ fn a_bunch() {
     check_str(
         result,
         "hi\
-        <span class=\"abc\" data-index=\"0\" data-hk=\"0-0-2\">\
-            <strong data-hk=\"0-0-3\">d</strong>3\
+        <span class=\"abc\" data-index=\"0\" data-hk=\"0-0-0-2\">\
+            <strong data-hk=\"0-0-0-3\">d</strong>\
+            3\
         </span>\
-        <br data-hk=\"0-0-4\"/>\
-        <input type=\"checkbox\" checked data-hk=\"0-0-5\"/>",
+        <br data-hk=\"0-0-0-4\"/>\
+        <input type=\"checkbox\" checked data-hk=\"0-0-0-5\"/>",
     );
 }
 

--- a/tests/spread.rs
+++ b/tests/spread.rs
@@ -17,7 +17,7 @@ fn spread_html_element() {
     };
     check_str(
         res,
-        r#"<div class="b" a="b" data-index="0" class="c" data-hk="0-0-1">children</div>"#,
+        r#"<div class="b" a="b" data-index="0" class="c" data-hk="0-0-0-1">children</div>"#,
     );
 }
 
@@ -35,6 +35,6 @@ fn spread_on_component() {
     };
     check_str(
         res,
-        r#"<div class="b" contenteditable data-index="0" data-hk="0-0-2"></div>"#,
+        r#"<div class="b" contenteditable data-index="0" data-hk="0-0-0-2"></div>"#,
     );
 }

--- a/tests/ui/errors/unsupported_attrs.rs
+++ b/tests/ui/errors/unsupported_attrs.rs
@@ -41,7 +41,7 @@ fn clone_on_element() {
     let notcopy = String::new();
     view! {
         div {
-            span clone:{notcopy} {
+            span clone:notcopy {
                 {notcopy.clone()}
             }
         }

--- a/tests/ui/errors/unsupported_attrs.stderr
+++ b/tests/ui/errors/unsupported_attrs.stderr
@@ -2,19 +2,19 @@ error: directive `style` is not supported on components
  --> tests/ui/errors/unsupported_attrs.rs:6:19
   |
 6 |         Component style:color="white";
-  |                   ^^^^^^^^^^^^^^^^^^^
+  |                   ^^^^^^^^^^^
 
 error: directive `class` is not supported on components
   --> tests/ui/errors/unsupported_attrs.rs:12:19
    |
 12 |         Component class:red={true};
-   |                   ^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^
 
 error: directive `prop` is not supported on components
   --> tests/ui/errors/unsupported_attrs.rs:18:19
    |
 18 |         Component prop:value="1";
-   |                   ^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^
 
 error: spread attributes not supported on components
   --> tests/ui/errors/unsupported_attrs.rs:30:19
@@ -26,13 +26,13 @@ error: directive `attr` is not supported on html elements
   --> tests/ui/errors/unsupported_attrs.rs:36:15
    |
 36 |         input attr:class="no" type="text";
-   |               ^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^
 
-error: directive `clone` is not supported on html elements
+error: directive `attr` is not supported on html elements
   --> tests/ui/errors/unsupported_attrs.rs:44:18
    |
-44 |             span clone:{notcopy} {
-   |                  ^^^^^^^^^^^^^^^
+44 |             span clone:notcopy {
+   |                  ^^^^^^^^^^^^^
 
 error: class/id selector shorthand is not supported on components
   --> tests/ui/errors/unsupported_attrs.rs:53:18

--- a/tests/ui/errors/use_directive.rs
+++ b/tests/ui/errors/use_directive.rs
@@ -1,0 +1,20 @@
+use leptos::{html::AnyElement, HtmlElement};
+use leptos_mview::view;
+
+fn no_arg_dir(_el: HtmlElement<AnyElement>) {}
+
+fn arg_dir(_el: HtmlElement<AnyElement>, _argument: i32) {}
+
+fn missing_argument() {
+    _ = view! {
+        div use:arg_dir;
+    };
+}
+
+fn extra_argument() {
+    _ = view! {
+        span use:no_arg_dir=2;
+    };
+}
+
+fn main() {}

--- a/tests/ui/errors/use_directive.stderr
+++ b/tests/ui/errors/use_directive.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> tests/ui/errors/use_directive.rs:10:17
+   |
+10 |         div use:arg_dir;
+   |             --- ^^^^^^^ expected `i32`, found `()`
+   |             |
+   |             arguments to this method are incorrect
+   |
+note: method defined here
+  --> $CARGO/leptos_dom-0.5.2/src/html.rs
+   |
+   |     pub fn directive<T: ?Sized, P: Clone + 'static>(
+   |            ^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/ui/errors/use_directive.rs:16:29
+   |
+16 |         span use:no_arg_dir=2;
+   |              ---            ^ expected `()`, found integer
+   |              |
+   |              arguments to this method are incorrect
+   |
+note: method defined here
+  --> $CARGO/leptos_dom-0.5.2/src/html.rs
+   |
+   |     pub fn directive<T: ?Sized, P: Clone + 'static>(
+   |            ^^^^^^^^^

--- a/tests/ui/pass/many_braces.rs
+++ b/tests/ui/pass/many_braces.rs
@@ -3,14 +3,14 @@
 use leptos_mview::view;
 
 fn main() {
-    view! {
+    _ = view! {
         div a={3} b={"aaaaa"} {
             {1234}
             span class={"braces not needed"} { "hi" }
         }
     };
 
-    view! {
+    _ = view! {
         button class:primary-200={true};
         button on:click={move |_| println!("hi")} {
             span 

--- a/tests/ui/pass/use_directive.rs
+++ b/tests/ui/pass/use_directive.rs
@@ -1,0 +1,31 @@
+use leptos::{*, html::AnyElement};
+use leptos_mview::view;
+
+fn no_arg_dir(_el: HtmlElement<AnyElement>) {}
+
+fn arg_dir(_el: HtmlElement<AnyElement>, _argument: i32) {}
+
+fn main() {
+    _ = view! {
+        div use:no_arg_dir {
+            span use:arg_dir=10;
+        }
+    };
+
+    _ = view! {
+        Component use:no_arg_dir;
+        Component use:arg_dir=300;
+    };
+}
+
+#[component]
+fn Component() -> impl IntoView {
+    view! { button { "hi" } }
+}
+
+#[component]
+fn Spreadable(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
+    view! {
+        div {..attrs};
+    }
+}


### PR DESCRIPTION
Adds support for directives without values, alongside the `use` directive.

**Breaking changes:**
- `clone:` now just takes `clone:thing_to_clone` instead of `clone:{thing_to_clone}`

**Features:**
- `use:` directive: same as leptos, `use:dir` or `use:dir={value}`