### PR TITLE
rename macro: `view!` -> `mview!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ A little preview of the syntax:
 
 ```rust
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 
 #[component]
 fn MyComponent() -> impl IntoView {
     let (value, set_value) = create_signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
-    view! {
+    mview! {
         h1.title { "A great website" }
         br;
 
@@ -34,7 +34,7 @@ fn MyComponent() -> impl IntoView {
 
         Show
             when=[!value().is_empty()]
-            fallback=[view! { "..." }]
+            fallback=[mview! { "..." }]
         {
             Await
                 future=[fetch_from_db(value())]
@@ -55,14 +55,14 @@ async fn fetch_from_db(data: String) -> usize { data.len() }
 
 ```rust
 use leptos::*;
-use leptos_mview::view; // override leptos::view
+use leptos_mview::mview; // override leptos::view
 
 #[component]
 fn MyComponent() -> impl IntoView {
     let (value, set_value) = create_signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
-    view! {
+    mview! {
         // specify tags and attributes, children go in braces
         // classes (and ids) can be added like CSS selectors.
         // same as `h1 class="title"`
@@ -136,7 +136,7 @@ Elements have the following structure:
 
 Example:
 ```rust
-view! {
+mview! {
     div.primary { strong { "hello world" } }
     input type="text" on:input={handle_input};
     MyComponent data=3 other="hi";
@@ -152,7 +152,7 @@ pub fn GenericComponent<S>(ty: PhantomData<S>) -> impl IntoView {
 
 #[component]
 pub fn App() -> impl IntoView {
-    view! {
+    mview! {
         GenericComponent<String> ty={PhantomData};
         GenericComponent<usize> ty={PhantomData};
         GenericComponent<i32> ty={PhantomData};
@@ -163,7 +163,7 @@ pub fn App() -> impl IntoView {
 Note that due to [Reserving syntax](https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html),
 the `#` for ids must have a space before it.
 ```rust
-view! {
+mview! {
     nav #primary { "..." }
     // not allowed: nav#primary { "..." }
 }
@@ -176,12 +176,12 @@ There are (currently) 3 main types of values you can pass in:
 - **Literals** can be passed in directly to attribute values (like `data=3`, `class="main"`, `checked=true`).
     - However, children do not accept literal numbers or bools - only strings.
         ```rust
-        view! { p { "this works " 0 " times: " true } }
+        mview! { p { "this works " 0 " times: " true } }
         ```
 
 - Everything else must be passed in as a **block**, including variables, closures, or expressions.
     ```rust
-    view! {
+    mview! {
         input
             class="main"
             checked=true
@@ -195,12 +195,12 @@ There are (currently) 3 main types of values you can pass in:
     ```rust
     let input_type = "text";
     // ❌ This is not valid! Wrap input_type in braces.
-    view! { input type=input_type }
+    mview! { input type=input_type }
     ```
 
 - Values wrapped in **brackets** (like `value=[a_bool().to_string()]`) are shortcuts for a block with an empty closure `move || ...` (to `value={move || a_bool().to_string()}`).
     ```rust
-    view! {
+    mview! {
         Show
             fallback=[()] // common for not wanting a fallback as `|| ()`
             when=[number() % 2 == 0] // `{move || number() % 2 == 0}`
@@ -211,15 +211,17 @@ There are (currently) 3 main types of values you can pass in:
     ```
 
     - Note that this always expands to `move || ...`: for any closures that take an argument, use the full closure block instead.
-        ```rust
-        view! {
+        ```compile_error
+        # use leptos_mview::mview;
+        # use leptos::logging::log;
+        mview! {
             input type="text" on:click=[log!("THIS DOESNT WORK")];
         }
         ```
 
         Instead:
         ```rust
-        view! {
+        mview! {
             input type="text" on:click={|_| log!("THIS WORKS!")};
         }
         ```
@@ -242,7 +244,7 @@ Most attributes are `key=value` pairs. The `value` follows the rules from above.
 
         Can be used elsewhere like this:
         ```rust
-        view! { Something some-attribute=5; }
+        mview! { Something some-attribute=5; }
         ```
 
         And the `some-attribute` will be passed in to the `some_attribute` argument.
@@ -251,7 +253,7 @@ Most attributes are `key=value` pairs. The `value` follows the rules from above.
     ```rust
     let class = "these are classes";
     let id = "primary";
-    view! {
+    mview! {
         div {class} {id} { "this has 3 classes and id='primary'" }
     }
     ```
@@ -268,9 +270,9 @@ Another shortcut is that boolean attributes can be written without adding `=true
 #[component]
 fn LotsOfFlags(wide: bool, tall: bool, red: bool, curvy: bool, count: i32) -> impl IntoView {}
 
-view! { LotsOfFlags wide tall red=false curvy count=3; }
+mview! { LotsOfFlags wide tall red=false curvy count=3; }
 // same as...
-view! { LotsOfFlags wide=true tall=true red=false curvy=true count=3; }
+mview! { LotsOfFlags wide=true tall=true red=false curvy=true count=3; }
 ```
 
 See also: [boolean attributes on HTML elements](#boolean-attributes-on-html-elements)
@@ -290,7 +292,7 @@ All of these directives except `clone` also support the attribute shorthand:
 ```rust
 let color = create_rw_signal("red".to_string());
 let disabled = false;
-view! {
+mview! {
     div style:{color} class:{disabled};
 }
 ```
@@ -298,7 +300,7 @@ view! {
 The `class` and `style` directives also support using string literals, for more complicated names or multiple classes at once.
 ```rust
 let yes = move || true;
-view! {
+mview! {
     div class:"complex-[class]-name"={yes}
         style:"doesn't-exist"="white"
         class:"class-one class-two"={yes};
@@ -311,7 +313,7 @@ You may have noticed that the `let:data` prop was missing from the previous sect
 
 This is replaced with a closure right before the children block. This way, you can pass in multiple arguments to the children more easily.
 ```rust
-view! {
+mview! {
     Await
         future=[async { 3 }]
     |monkeys| {
@@ -332,19 +334,19 @@ If an attribute shorthand has hyphens:
 - On components, both the key and value will be converted to underscores.
     ```rust
     let some_attribute = 5;
-    view! { Something {some-attribute}; }
+    mview! { Something {some-attribute}; }
     // same as...
-    view! { Something {some_attribute}; }
+    mview! { Something {some_attribute}; }
     // same as...
-    view! { Something some_attribute={some_attribute}; }
+    mview! { Something some_attribute={some_attribute}; }
     ```
 
 - On HTML elements, the key will keep hyphens, but the value will be turned into an identifier with underscores.
     ```rust
     let aria_label = "a good label";
-    view! { input {aria-label}; }
+    mview! { input {aria-label}; }
     // same as...
-    view! { input aria-label={aria_label}; }
+    mview! { input aria-label={aria_label}; }
     ```
 
 ### Boolean attributes on HTML elements
@@ -361,9 +363,9 @@ To have the attribute have a value of the string "true" or "false", use `.to_str
 Especially using the closure shorthand `[...]`, this can be pretty simple when working with signals:
 ```rust
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 let boolean_signal = create_rw_signal(true);
-view! { input type="checkbox" checked=[boolean_signal().to_string()]; }
+mview! { input type="checkbox" checked=[boolean_signal().to_string()]; }
 ```
 
 ## Contributing

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -28,8 +28,9 @@ use crate::{
 /// # Example
 /// ```ignore
 /// use leptos::*;
+/// use leptos_mview::mview;
 /// let div = create_node_ref::<html::Div>();
-/// view! {
+/// mview! {
 ///     div
 ///         class="component"
 ///         style:color="black"

--- a/leptos-mview-core/src/lib.rs
+++ b/leptos-mview-core/src/lib.rs
@@ -23,9 +23,9 @@ use quote::quote;
 use crate::{children::Children, expand::children_fragment_tokens};
 
 #[must_use]
-pub fn component(input: TokenStream) -> TokenStream {
+pub fn mview_impl(input: TokenStream) -> TokenStream {
     // return () in case of any errors, to avoid "unexpected end of macro
-    // invocation" e.g. when assigning `let res = view! { ... };`
+    // invocation" e.g. when assigning `let res = mview! { ... };`
     proc_macro_error::set_dummy(quote! { () });
 
     let children = match syn::parse2::<Children>(input) {

--- a/leptos-mview-macro/src/lib.rs
+++ b/leptos-mview-macro/src/lib.rs
@@ -4,6 +4,6 @@ use proc_macro_error::proc_macro_error;
 #[proc_macro_error]
 #[proc_macro]
 #[rustfmt::skip]
-pub fn view(input: TokenStream) -> TokenStream {
-    leptos_mview_core::component(input.into()).into()
+pub fn mview(input: TokenStream) -> TokenStream {
+    leptos_mview_core::mview_impl(input.into()).into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@ A little preview of the syntax:
 
 ```
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 
 #[component]
 fn MyComponent() -> impl IntoView {
     let (value, set_value) = create_signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
-    view! {
+    mview! {
         h1.title { "A great website" }
         br;
 
@@ -33,7 +33,7 @@ fn MyComponent() -> impl IntoView {
 
         Show
             when=[!value().is_empty()]
-            fallback=[view! { "..." }]
+            fallback=[mview! { "..." }]
         {
             Await
                 future=[fetch_from_db(value())]
@@ -54,14 +54,14 @@ async fn fetch_from_db(data: String) -> usize { data.len() }
 
 ```
 use leptos::*;
-use leptos_mview::view; // override leptos::view
+use leptos_mview::mview; // override leptos::view
 
 #[component]
 fn MyComponent() -> impl IntoView {
     let (value, set_value) = create_signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
-    view! {
+    mview! {
         // specify tags and attributes, children go in braces
         // classes (and ids) can be added like CSS selectors.
         // same as `h1 class="title"`
@@ -81,7 +81,7 @@ fn MyComponent() -> impl IntoView {
         Show
             // values wrapped in brackets `[body]` are expanded to `{move || body}`
             when=[!value().is_empty()] // `{move || !value().is_empty()}`
-            fallback=[view! { "..." }] // `{move || view! { "..." }}`
+            fallback=[mview! { "..." }] // `{move || mview! { "..." }}`
         { // I recommend placing children like this when attributes are multi-line
             Await
                 future=[fetch_from_db(value())]
@@ -135,10 +135,10 @@ Elements have the following structure:
 
 Example:
 ```
-# use leptos_mview::view; use leptos::*;
+# use leptos_mview::mview; use leptos::*;
 # let handle_input = |_| ();
 # #[component] fn MyComponent(data: i32, other: &'static str) -> impl IntoView {}
-view! {
+mview! {
     div.primary { strong { "hello world" } }
     input type="text" on:input={handle_input};
     MyComponent data=3 other="hi";
@@ -148,7 +148,7 @@ view! {
 
 Adding generics is the same as in leptos: add it directly after the component name, without the turbofish `::<...>`.
 ```
-# use leptos::*; use leptos_mview::view;
+# use leptos::*; use leptos_mview::mview;
 # use core::marker::PhantomData;
 #[component]
 pub fn GenericComponent<S>(ty: PhantomData<S>) -> impl IntoView {
@@ -157,7 +157,7 @@ pub fn GenericComponent<S>(ty: PhantomData<S>) -> impl IntoView {
 
 #[component]
 pub fn App() -> impl IntoView {
-    view! {
+    mview! {
         GenericComponent<String> ty={PhantomData};
         GenericComponent<usize> ty={PhantomData};
         GenericComponent<i32> ty={PhantomData};
@@ -168,8 +168,8 @@ pub fn App() -> impl IntoView {
 Note that due to [Reserving syntax](https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html),
 the `#` for ids must have a space before it.
 ```
-# use leptos_mview::view;
-view! {
+# use leptos_mview::mview;
+mview! {
     nav #primary { "..." }
     // not allowed: nav#primary { "..." }
 }
@@ -183,17 +183,17 @@ There are (currently) 3 main types of values you can pass in:
 - **Literals** can be passed in directly to attribute values (like `data=3`, `class="main"`, `checked=true`).
     - However, children do not accept literal numbers or bools - only strings.
         ```compile_fail
-        # use leptos_mview::view;
-        view! { p { "this works " 0 " times: " true } }
+        # use leptos_mview::mview;
+        mview! { p { "this works " 0 " times: " true } }
         # ;
         ```
 
 - Everything else must be passed in as a **block**, including variables, closures, or expressions.
     ```
-    # use leptos_mview::view;
+    # use leptos_mview::mview;
     # let input_type = "text";
     # let handle_input = |_a: i32| ();
-    view! {
+    mview! {
         input
             class="main"
             checked=true
@@ -206,18 +206,18 @@ There are (currently) 3 main types of values you can pass in:
 
     This is not valid:
     ```compile_fail
-    # use leptos_mview::view;
+    # use leptos_mview::mview;
     let input_type = "text";
     // ❌ This is not valid! Wrap input_type in braces.
-    view! { input type=input_type }
+    mview! { input type=input_type }
     # ;
     ```
 
 - Values wrapped in **brackets** (like `value=[a_bool().to_string()]`) are shortcuts for a block with an empty closure `move || ...` (to `value={move || a_bool().to_string()}`).
     ```rust
-    # use leptos::*; use leptos_mview::view;
+    # use leptos::*; use leptos_mview::mview;
     # let number = || 3;
-    view! {
+    mview! {
         Show
             fallback=[()] // common for not wanting a fallback as `|| ()`
             when=[number() % 2 == 0] // `{move || number() % 2 == 0}`
@@ -230,18 +230,18 @@ There are (currently) 3 main types of values you can pass in:
 
     - Note that this always expands to `move || ...`: for any closures that take an argument, use the full closure block instead.
         ```compile_error
-        # use leptos_mview::view;
+        # use leptos_mview::mview;
         # use leptos::logging::log;
-        view! {
+        mview! {
             input type="text" on:click=[log!("THIS DOESNT WORK")];
         }
         ```
 
         Instead:
         ```
-        # use leptos_mview::view;
+        # use leptos_mview::mview;
         # use leptos::logging::log;
-        view! {
+        mview! {
             input type="text" on:click={|_| log!("THIS WORKS!")};
         }
         # ;
@@ -265,9 +265,9 @@ Most attributes are `key=value` pairs. The `value` follows the rules from above.
 
         Can be used elsewhere like this:
         ```
-        # use leptos::*; use leptos_mview::view;
+        # use leptos::*; use leptos_mview::mview;
         # #[component] fn Something(some_attribute: i32) -> impl IntoView {}
-        view! { Something some-attribute=5; }
+        mview! { Something some-attribute=5; }
         # ;
         ```
 
@@ -275,10 +275,10 @@ Most attributes are `key=value` pairs. The `value` follows the rules from above.
 
 - Attribute shorthand: if the name of the attribute and value are the same, e.g. `class={class}`, you can replace this with `{class}` to mean the same thing.
     ```
-    # use leptos_mview::view;
+    # use leptos_mview::mview;
     let class = "these are classes";
     let id = "primary";
-    view! {
+    mview! {
         div {class} {id} { "this has 3 classes and id='primary'" }
     }
     # ;
@@ -292,15 +292,15 @@ Note that the special `node_ref` or `ref` or `_ref` or `ref_` attribute in Lepto
 
 Another shortcut is that boolean attributes can be written without adding `=true`. Watch out though! `checked` is **very different** to `{checked}`.
 ```
-# use leptos::*; use leptos_mview::view;
+# use leptos::*; use leptos_mview::mview;
 // recommend usually adding #[prop(optional)] to all these
 #[component]
 fn LotsOfFlags(wide: bool, tall: bool, red: bool, curvy: bool, count: i32) -> impl IntoView {}
 
-view! { LotsOfFlags wide tall red=false curvy count=3; }
+mview! { LotsOfFlags wide tall red=false curvy count=3; }
 # ;
 // same as...
-view! { LotsOfFlags wide=true tall=true red=false curvy=true count=3; }
+mview! { LotsOfFlags wide=true tall=true red=false curvy=true count=3; }
 # ;
 ```
 
@@ -319,10 +319,10 @@ Some special attributes (distinguished by the `:`) called **directives** have sp
 
 All of these directives except `clone` also support the attribute shorthand:
 ```
-# use leptos::*; use leptos_mview::view;
+# use leptos::*; use leptos_mview::mview;
 let color = create_rw_signal("red".to_string());
 let disabled = false;
-view! {
+mview! {
     div style:{color} class:{disabled};
 }
 # ;
@@ -330,9 +330,9 @@ view! {
 
 The `class` and `style` directives also support using string literals, for more complicated names or multiple classes at once.
 ```
-# use leptos::*; use leptos_mview::view;
+# use leptos::*; use leptos_mview::mview;
 let yes = move || true;
-view! {
+mview! {
     div class:"complex-[class]-name"={yes}
         style:"doesn't-exist"="white"
         class:"class-one class-two"={yes};
@@ -346,8 +346,8 @@ You may have noticed that the `let:data` prop was missing from the previous sect
 
 This is replaced with a closure right before the children block. This way, you can pass in multiple arguments to the children more easily.
 ```
-# use leptos::*; use leptos_mview::view;
-view! {
+# use leptos::*; use leptos_mview::mview;
+mview! {
     Await
         future=[async { 3 }]
     |monkeys| {
@@ -368,27 +368,27 @@ Summary from the previous section on values in case you missed it: children can 
 If an attribute shorthand has hyphens:
 - On components, both the key and value will be converted to underscores.
     ```
-    # use leptos::*; use leptos_mview::view;
+    # use leptos::*; use leptos_mview::mview;
     # #[component] fn Something(some_attribute: i32) -> impl IntoView {}
     let some_attribute = 5;
-    view! { Something {some-attribute}; }
+    mview! { Something {some-attribute}; }
     # ;
     // same as...
-    view! { Something {some_attribute}; }
+    mview! { Something {some_attribute}; }
     # ;
     // same as...
-    view! { Something some_attribute={some_attribute}; }
+    mview! { Something some_attribute={some_attribute}; }
     # ;
     ```
 
 - On HTML elements, the key will keep hyphens, but the value will be turned into an identifier with underscores.
     ```
-    # use leptos_mview::view;
+    # use leptos_mview::mview;
     let aria_label = "a good label";
-    view! { input {aria-label}; }
+    mview! { input {aria-label}; }
     # ;
     // same as...
-    view! { input aria-label={aria_label}; }
+    mview! { input aria-label={aria_label}; }
     # ;
     ```
 
@@ -407,9 +407,9 @@ To have the attribute have a value of the string "true" or "false", use `.to_str
 Especially using the closure shorthand `[...]`, this can be pretty simple when working with signals:
 ```
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 let boolean_signal = create_rw_signal(true);
-view! { input type="checkbox" checked=[boolean_signal().to_string()]; }
+mview! { input type="checkbox" checked=[boolean_signal().to_string()]; }
 # ;
 ```
 
@@ -429,4 +429,4 @@ Please feel free to make a PR/issue if you have feature ideas/bugs to report/fee
 // Some bits are slightly broken, fix up stray `compile_error`/
 // `ignore`, missing `rust` annotations and remove `#` lines.
 
-pub use leptos_mview_macro::view;
+pub use leptos_mview_macro::mview;

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -1,5 +1,5 @@
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 mod utils;
 use utils::check_str;
 
@@ -7,11 +7,11 @@ use utils::check_str;
 fn clones() {
     #[component]
     fn Owning(children: ChildrenFn) -> impl IntoView {
-        view! { div { {children} } }
+        mview! { div { {children} } }
     }
 
     let notcopy = String::new();
-    _ = view! {
+    _ = mview! {
         Owning {
             Owning clone:notcopy {
                 {notcopy.clone()}
@@ -23,7 +23,7 @@ fn clones() {
 // TODO: not sure why this is creating an untracked resource warning
 #[test]
 fn children_args() {
-    _ = view! {
+    _ = mview! {
         Await future={|| async { 3 }} |data| {
             p { {*data} " little monkeys, jumping on the bed." }
         }
@@ -31,7 +31,7 @@ fn children_args() {
 
     // clone should also work
     let name = String::new();
-    _ = view! {
+    _ = mview! {
         Await
             future={move || async {"hi".to_string()}}
             clone:name
@@ -51,7 +51,7 @@ fn generics() {
         std::any::type_name::<S>()
     }
 
-    let result = view! {
+    let result = mview! {
         GenericComponent<String> ty={PhantomData};
         GenericComponent<usize> ty={PhantomData};
         GenericComponent<i32> ty={PhantomData};
@@ -64,7 +64,7 @@ fn generics() {
 fn let_patterns() {
     if false {
         let letters = ['a', 'b', 'c'];
-        _ = view! {
+        _ = mview! {
             For
                 each=[letters.into_iter().enumerate()]
                 key={|(i, _)| *i}

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,11 +1,11 @@
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 mod utils;
 use utils::check_str;
 
 #[test]
 fn strings() {
-    let result: &str = view! {
+    let result: &str = mview! {
         "hello there!"
     };
     assert_eq!(result, "hello there!");
@@ -17,7 +17,7 @@ fn strings() {
 
 #[test]
 fn single_element() {
-    let result: HtmlElement<html::Div> = view! {
+    let result: HtmlElement<html::Div> = mview! {
         div {
             "hi"
         }
@@ -27,7 +27,7 @@ fn single_element() {
 
 #[test]
 fn multi_element_is_fragment() {
-    let _fragment: Fragment = view! {
+    let _fragment: Fragment = mview! {
         div { "a" }
         span { "b" }
     };
@@ -35,7 +35,7 @@ fn multi_element_is_fragment() {
 
 #[test]
 fn a_bunch() {
-    let result = view! {
+    let result = mview! {
         "hi"
         span class="abc" data-index={0} {
             strong { "d" }
@@ -59,12 +59,12 @@ fn a_bunch() {
 
 #[test]
 fn directive_before_attr() {
-    let result = view! {
+    let result = mview! {
         span class:exist=true class="dont override";
     };
     check_str(result, "dont override exist");
 
-    let result = view! {
+    let result = mview! {
         span style:color="black" style="font-size: 1em;";
     };
     check_str(result, "font-size: 1em; color: black;");
@@ -75,7 +75,7 @@ fn multiple_directives() {
     let yes = move || true;
     let no = move || false;
     let color = move || "white";
-    let result = view! {
+    let result = mview! {
         div
             class:here={yes}
             style:color={color}
@@ -95,7 +95,7 @@ fn multiple_directives() {
 #[test]
 fn string_directives() {
     let yes = move || true;
-    let result = view! {
+    let result = mview! {
         div
             class:"complex[class]-name"={yes}
             style:"doesn't-exist"="black"

--- a/tests/spread.rs
+++ b/tests/spread.rs
@@ -1,5 +1,5 @@
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 mod utils;
 use utils::check_str;
 
@@ -10,7 +10,7 @@ fn spread_html_element() {
         ("data-index", 0.into_attribute()),
         ("class", "c".into_attribute()),
     ];
-    let res = view! {
+    let res = mview! {
         div {..attrs} class="b" {
             "children"
         }
@@ -25,12 +25,12 @@ fn spread_html_element() {
 fn spread_on_component() {
     #[component]
     fn Spreadable(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
-        view! {
+        mview! {
             div {..attrs};
         }
     }
 
-    let res = view! {
+    let res = mview! {
         Spreadable attr:class="b" attr:contenteditable=true attr:data-index=0;
     };
     check_str(

--- a/tests/ui/errors/invalid_child.rs
+++ b/tests/ui/errors/invalid_child.rs
@@ -1,8 +1,8 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
     let a = "a";
-    view! {
+    mview! {
         (a)
     };
 }

--- a/tests/ui/errors/invalid_directive.rs
+++ b/tests/ui/errors/invalid_directive.rs
@@ -1,25 +1,25 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn not_directive() {
-    view! {
+    mview! {
         div something:yes="b" {}
     };
 }
 
 fn not_class_name() {
-    view! {
+    mview! {
         div class:("abcd") = true {}
     };
 }
 
 fn not_style_name() {
-    view! {
+    mview! {
         div style:[1, 2]="black" {}
     };
 }
 
 fn not_event_name() {
-    view! {
+    mview! {
         button on:clicky-click={move |_| ()};
     };
 }

--- a/tests/ui/errors/invalid_value.rs
+++ b/tests/ui/errors/invalid_value.rs
@@ -1,7 +1,7 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    view! {
+    mview! {
         div a=a {}
     };
 }

--- a/tests/ui/errors/no_children_after_closure.rs
+++ b/tests/ui/errors/no_children_after_closure.rs
@@ -1,7 +1,7 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    view! {
+    mview! {
         Await
             future=[async { 1 }]
         |data| "no"

--- a/tests/ui/errors/non_str_child.rs
+++ b/tests/ui/errors/non_str_child.rs
@@ -1,7 +1,7 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    view! {
+    mview! {
         div { 3 }
     };
 }

--- a/tests/ui/errors/return_expression.rs
+++ b/tests/ui/errors/return_expression.rs
@@ -1,8 +1,8 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
     // should not get an "unexpected end of macro invocation"
-    let expr = view! {
+    let expr = mview! {
         div class=;
     };
 }

--- a/tests/ui/errors/turbofish.rs
+++ b/tests/ui/errors/turbofish.rs
@@ -1,5 +1,5 @@
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
     use core::marker::PhantomData;
@@ -10,7 +10,7 @@ fn main() {
         std::any::type_name::<S>()
     }
 
-    view! {
+    mview! {
         GenericComponent::<String> ty={PhantomData};
     };
 }

--- a/tests/ui/errors/unsupported_attrs.rs
+++ b/tests/ui/errors/unsupported_attrs.rs
@@ -1,20 +1,20 @@
 use leptos::*;
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn style_on_component() {
-    view! {
+    mview! {
         Component style:color="white";
     };
 }
 
 fn class_on_component() {
-    view! {
+    mview! {
         Component class:red={true};
     };
 }
 
 fn prop_on_component() {
-    view! {
+    mview! {
         Component prop:value="1";
     };
 }
@@ -26,20 +26,20 @@ fn SpreadOnComponent() -> impl IntoView {
         ("class", "something"),
         ("data", "a"),
     ];
-    view! {
+    mview! {
         Component {..attrs};
     };
 }
 
 fn attr_on_element() {
-    view! {
+    mview! {
         input attr:class="no" type="text";
     };
 }
 
 fn clone_on_element() {
     let notcopy = String::new();
-    view! {
+    mview! {
         div {
             span clone:notcopy {
                 {notcopy.clone()}
@@ -49,14 +49,14 @@ fn clone_on_element() {
 }
 
 fn sel_shorthand_on_components() {
-    view! {
+    mview! {
         Component.not-working #some-id;
     };
 }
 
 #[component]
 fn Component() -> impl IntoView {
-    view! {
+    mview! {
         button;
     };
 }

--- a/tests/ui/errors/unterminated_element.rs
+++ b/tests/ui/errors/unterminated_element.rs
@@ -1,7 +1,7 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    view! {
+    mview! {
         input type="text"
         "hi"
     };

--- a/tests/ui/errors/unterminated_element_warning.rs
+++ b/tests/ui/errors/unterminated_element_warning.rs
@@ -1,7 +1,7 @@
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    _ = view! {
+    _ = mview! {
         div {
             "something"
             input.input type="text"

--- a/tests/ui/errors/use_directive.rs
+++ b/tests/ui/errors/use_directive.rs
@@ -1,18 +1,18 @@
 use leptos::{html::AnyElement, HtmlElement};
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn no_arg_dir(_el: HtmlElement<AnyElement>) {}
 
 fn arg_dir(_el: HtmlElement<AnyElement>, _argument: i32) {}
 
 fn missing_argument() {
-    _ = view! {
+    _ = mview! {
         div use:arg_dir;
     };
 }
 
 fn extra_argument() {
-    _ = view! {
+    _ = mview! {
         span use:no_arg_dir=2;
     };
 }

--- a/tests/ui/pass/many_braces.rs
+++ b/tests/ui/pass/many_braces.rs
@@ -1,16 +1,16 @@
 #![deny(unused_braces)]
 
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn main() {
-    _ = view! {
+    _ = mview! {
         div a={3} b={"aaaaa"} {
             {1234}
             span class={"braces not needed"} { "hi" }
         }
     };
 
-    _ = view! {
+    _ = mview! {
         button class:primary-200={true};
         button on:click={move |_| println!("hi")} {
             span 

--- a/tests/ui/pass/use_directive.rs
+++ b/tests/ui/pass/use_directive.rs
@@ -1,18 +1,18 @@
 use leptos::{*, html::AnyElement};
-use leptos_mview::view;
+use leptos_mview::mview;
 
 fn no_arg_dir(_el: HtmlElement<AnyElement>) {}
 
 fn arg_dir(_el: HtmlElement<AnyElement>, _argument: i32) {}
 
 fn main() {
-    _ = view! {
+    _ = mview! {
         div use:no_arg_dir {
             span use:arg_dir=10;
         }
     };
 
-    _ = view! {
+    _ = mview! {
         Component use:no_arg_dir;
         Component use:arg_dir=300;
     };
@@ -20,12 +20,12 @@ fn main() {
 
 #[component]
 fn Component() -> impl IntoView {
-    view! { button { "hi" } }
+    mview! { button { "hi" } }
 }
 
 #[component]
 fn Spreadable(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
-    view! {
+    mview! {
         div {..attrs};
     }
 }


### PR DESCRIPTION
Absolutely breaking change: renamed the macro from `view!` to `mview!`. This allows you to use the leptos `view!` macro when needed without using the fully qualified path.