### PR TITLE
More attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ mview! {
 }
 ```
 
+Classes/ids created with the selector syntax can be mixed with the attribute `class="..."` and directive `class:a-class={signal}` as well.
+
 ### Slots
 
 [Slots](https://docs.rs/leptos/latest/leptos/attr.slot.html) ([another example](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs)) are supported by prefixing the struct with `slot:` inside the parent's children.
@@ -351,8 +353,8 @@ If a component has a `class` attribute, the classes using the selector syntax `.
 // the `class` parameter should have these attributes and type to work properly
 fn TakesClasses(#[prop(into, default="".into())] class: TextProp) -> impl IntoView {
     mview! {
-        // use the f[] value feature to have an existing class + any extras passed in
-        div class=f["my-component {}", class.get()] { "..." }
+        // "my-component" will always be present, extra classes passed in will also be added
+        div.my-component class=[class.get()] { "..." }
     }
 }
 
@@ -374,7 +376,7 @@ signal.set(false);
 // becomes <div class="my-component always-has-this">
 ```
 
-There is one small difference from the `class:` syntax on HTML elements: the value  passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
+There is one small difference from the `class:` syntax on HTML elements: the value passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
 
 This is also supported with an `id` attribute to forward `#my-id`, though not reactively.
 ```rust

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn MyComponent() -> impl IntoView {
                 blocking
             |db_info| {
                 p { "Things found: " strong { {*db_info} } "!" }
-                p { "Is bad: " [red_input().to_string()] }
+                p { "Is bad: " f["{}", red_input()] }
             }
         }
     }
@@ -94,8 +94,9 @@ fn MyComponent() -> impl IntoView {
             |db_info| {
                 p { "Things found: " strong { {*db_info} } "!" }
                 // bracketed expansion works in children too!
-                //             {move || red_input().to_string()}
-                p { "Is bad: " [red_input().to_string()] }
+                // this one also has a special prefix to add `format!` into the expansion!
+                //    {move || format!("{}", red_input()}
+                p { "Is bad: " f["{}", red_input()] }
             }
         }
     }
@@ -255,6 +256,9 @@ There are (currently) 3 main types of values you can pass in:
             input type="text" on:click={|_| log!("THIS WORKS!")};
         }
         ```
+
+The bracketed values can also have some special prefixes for even more common shortcuts!
+- Currently, the only one is `f` - e.g. `f["{:.2}", stuff()]`. Adding an `f` will add `format!` into the closure. This is equivalent to `[format!("{:.2}", stuff())]` or `{move || format!("{:.2}", stuff())}`.
 
 ### Attributes
 

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Please feel free to make a PR/issue if you have feature ideas/bugs to report/fee
 
 ### Extra feature ideas
 
-- [ ] [Extending `class` attribute support](https://github.com/leptos-rs/leptos/issues/1492)
+- [x] [Extending `class` attribute support](https://github.com/leptos-rs/leptos/issues/1492)
 - [ ] [SSR optimisation](https://github.com/leptos-rs/leptos/issues/1492#issuecomment-1664675672) (potential `delegate` feature that transforms this macro into a `leptos::view!` macro call as well?)
 - [x] Support slots
  

--- a/README.md
+++ b/README.md
@@ -331,13 +331,12 @@ mview! {
 }
 ```
 
-The `class` and `style` directives also support using string literals, for more complicated names or multiple classes at once.
+The `class` and `style` directives also support using string literals, for more complicated names. Make sure the string for `class:` doesn't have spaces, or it will panic!
 ```rust
 let yes = move || true;
 mview! {
     div class:"complex-[class]-name"={yes}
-        style:"doesn't-exist"="white"
-        class:"class-one class-two"={yes};
+        style:"doesn't-exist"="white";
 }
 ```
 
@@ -390,7 +389,7 @@ fn TakesIds(#[prop(optional)] id: &'static str) -> impl IntoView {
 // <div id="my-unique-id">
 mview! {
     TakesIds #my-unique-id;
-}
+};
 ```
 
 This is also supported on slots by having a `class` and `id` field with the same attributes and types as the components above.
@@ -413,6 +412,8 @@ mview! {
 Note that you will usually need to add a `*` before the data you are using. If you forget that, rust-analyser will tell you to dereference here: `*{monkeys}`. This is obviously invalid - put it inside the braces. (If anyone knows how to fix this, feel free to contribute!)
 
 Summary from the previous section on values in case you missed it: children can be literal strings (not bools or numbers!), blocks with Rust code inside (`{*monkeys}`), or the closure shorthand `[number() + 1]`.
+
+Children with closures are also supported on slots, add a field `children: Callback<T, View>` to use it (`T` is whatever type you want).
 
 ## Extra details
 

--- a/leptos-mview-core/src/ast/attribute/parsing.rs
+++ b/leptos-mview-core/src/ast/attribute/parsing.rs
@@ -191,10 +191,10 @@ impl BracedKebabIdent {
     pub const fn ident(&self) -> &KebabIdent { &self.ident }
 
     pub fn into_block_value(self) -> Value {
-        Value::Block(
-            self.ident().to_snake_ident().into_token_stream(),
-            self.brace_token,
-        )
+        Value::Block {
+            tokens: self.ident().to_snake_ident().into_token_stream(),
+            braces: self.brace_token,
+        }
     }
 }
 
@@ -226,7 +226,10 @@ impl BracedIdent {
     pub const fn ident(&self) -> &syn::Ident { &self.ident }
 
     pub fn into_block_value(self) -> Value {
-        Value::Block(self.ident().into_token_stream(), self.brace_token)
+        Value::Block {
+            tokens: self.ident().into_token_stream(),
+            braces: self.brace_token,
+        }
     }
 }
 

--- a/leptos-mview-core/src/ast/element.rs
+++ b/leptos-mview-core/src/ast/element.rs
@@ -118,11 +118,9 @@ impl Parse for Element {
 
 impl ToTokens for Element {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        tokens.extend(
-            xml_to_tokens(self).unwrap_or_else(|| {
-                component_to_tokens(self).expect("element should be a component")
-            }),
-        );
+        tokens.extend(xml_to_tokens(self).unwrap_or_else(|| {
+            component_to_tokens::<false>(self).expect("element should be a component")
+        }));
     }
 }
 

--- a/leptos-mview-core/src/ast/ident.rs
+++ b/leptos-mview-core/src/ast/ident.rs
@@ -60,6 +60,10 @@ impl KebabIdent {
         )
     }
 
+    pub fn spans(&self) -> &[Span] {
+        &self.spans
+    }
+
     /// Converts this ident to a `syn::LitStr` of the ident's repr with the
     /// appropriate span.
     pub fn to_lit_str(&self) -> syn::LitStr { syn::LitStr::new(self.repr(), self.span()) }

--- a/leptos-mview-core/src/ast/ident.rs
+++ b/leptos-mview-core/src/ast/ident.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
-use proc_macro2::Span;
-use quote::{quote_spanned, ToTokens};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     ext::IdentExt,
     parse::{Parse, ParseStream},
@@ -60,13 +60,32 @@ impl KebabIdent {
         )
     }
 
-    pub fn spans(&self) -> &[Span] {
-        &self.spans
-    }
+    /// Returns an iterator of every span in this [`KebabIdent`].
+    ///
+    /// Spans usually need to be owned, so an iterator that produces owned spans
+    /// is returned.
+    pub fn spans(&self) -> impl ExactSizeIterator<Item = Span> + '_ { self.spans.iter().copied() }
 
     /// Converts this ident to a `syn::LitStr` of the ident's repr with the
     /// appropriate span.
     pub fn to_lit_str(&self) -> syn::LitStr { syn::LitStr::new(self.repr(), self.span()) }
+
+    /// Expands this ident to its string literal, along with dummy items to make
+    /// each segment the same color as a variable.
+    ///
+    /// **NOTE:** The string itself won't be spanned to this [`KebabIdent`].
+    /// Make sure that where this is used will always take a string and never
+    /// errors.
+    ///
+    /// The [`TokenStream`] returned is a block expression, so make sure that
+    /// blocks can be used in the context where this is expanded.
+    pub fn to_str_colored(&self) -> TokenStream {
+        let dummy_items = span::color_all(self.spans());
+        let string = self.repr();
+        quote! {
+            {#(#dummy_items)* #string}
+        }
+    }
 
     /// Converts this ident to a `syn::Ident` with the appropriate span, by
     /// replacing all `-`s with `_`.

--- a/leptos-mview-core/src/ast/tag.rs
+++ b/leptos-mview-core/src/ast/tag.rs
@@ -71,17 +71,6 @@ impl Tag {
             Self::WebComponent(ident) => ident.span(),
         }
     }
-
-    /// Returns the [`TagKind`] of this [`Tag`].
-    pub const fn kind(&self) -> TagKind {
-        match self {
-            Self::Html(_) => TagKind::Html,
-            Self::Component(..) => TagKind::Component,
-            Self::Svg(_) => TagKind::Svg,
-            Self::Math(_) => TagKind::Math,
-            Self::WebComponent(_) => TagKind::WebComponent,
-        }
-    }
 }
 
 impl Parse for Tag {

--- a/leptos-mview-core/src/ast/value.rs
+++ b/leptos-mview-core/src/ast/value.rs
@@ -89,7 +89,8 @@ impl ToTokens for Value {
                 if let Some(prefixes) = prefixes {
                     // only f[] is supported for now
                     if prefixes == "f" {
-                        quote_spanned!(brackets.span.join()=> move || ::std::format!(#tokens))
+                        let format = quote_spanned!(prefixes.span()=> format!);
+                        quote_spanned!(brackets.span.join()=> move || ::std::#format(#tokens))
                     } else {
                         abort!(
                             prefixes.span(),

--- a/leptos-mview-core/src/ast/value.rs
+++ b/leptos-mview-core/src/ast/value.rs
@@ -1,6 +1,10 @@
 use proc_macro2::{Span, TokenStream};
+use proc_macro_error::abort;
 use quote::{quote_spanned, ToTokens};
-use syn::parse::{Parse, ParseStream};
+use syn::{
+    ext::IdentExt,
+    parse::{Parse, ParseStream},
+};
 
 use crate::parse;
 
@@ -28,8 +32,15 @@ pub enum Value {
     Lit(syn::Lit),
     // take a raw `TokenStream` instead of ExprBlock/etc for better r-a support
     // as invalid expressions aren't completely rejected
-    Block(TokenStream, syn::token::Brace),
-    Bracket(TokenStream, syn::token::Bracket),
+    Block {
+        tokens: TokenStream,
+        braces: syn::token::Brace,
+    },
+    Bracket {
+        tokens: TokenStream,
+        brackets: syn::token::Bracket,
+        prefixes: Option<syn::Ident>,
+    },
 }
 
 impl Parse for Value {
@@ -37,11 +48,26 @@ impl Parse for Value {
         if input.peek(syn::token::Bracket) {
             let stream;
             let brackets = syn::bracketed!(stream in input);
-            let stream = stream.parse::<TokenStream>().unwrap();
-            Ok(Self::Bracket(stream, brackets))
+            let tokens = stream.parse::<TokenStream>().unwrap();
+            Ok(Self::Bracket {
+                tokens,
+                brackets,
+                prefixes: None,
+            })
+        // with prefixes like `f["{}", something]`
+        } else if input.peek(syn::Ident::peek_any) && input.peek2(syn::token::Bracket) {
+            let prefixes = input.call(syn::Ident::parse_any).unwrap();
+            let stream;
+            let brackets = syn::bracketed!(stream in input);
+            let tokens = stream.parse::<TokenStream>().unwrap();
+            Ok(Self::Bracket {
+                tokens,
+                brackets,
+                prefixes: Some(prefixes),
+            })
         } else if input.peek(syn::token::Brace) {
-            let (stream, braces) = parse::parse_braced::<TokenStream>(input).unwrap();
-            Ok(Self::Block(stream, braces))
+            let (tokens, braces) = parse::parse_braced::<TokenStream>(input).unwrap();
+            Ok(Self::Block { tokens, braces })
         } else if let Ok(lit) = input.parse::<syn::Lit>() {
             Ok(Self::Lit(lit))
         } else {
@@ -54,8 +80,26 @@ impl ToTokens for Value {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         tokens.extend(match self {
             Self::Lit(lit) => lit.into_token_stream(),
-            Self::Block(stream, braces) => quote_spanned!(braces.span.join()=> {#stream}),
-            Self::Bracket(expr, brackets) => quote_spanned! {brackets.span.join()=> move || #expr},
+            Self::Block { tokens, braces } => quote_spanned!(braces.span.join()=> {#tokens}),
+            Self::Bracket {
+                tokens,
+                prefixes,
+                brackets,
+            } => {
+                if let Some(prefixes) = prefixes {
+                    // only f[] is supported for now
+                    if prefixes == "f" {
+                        quote_spanned!(brackets.span.join()=> move || ::std::format!(#tokens))
+                    } else {
+                        abort!(
+                            prefixes.span(),
+                            "unsupported prefix: only `f` is supported."
+                        )
+                    }
+                } else {
+                    quote_spanned!(brackets.span.join()=> move || #tokens)
+                }
+            }
         });
     }
 }
@@ -67,8 +111,8 @@ impl Value {
     pub fn span(&self) -> Span {
         match self {
             Self::Lit(lit) => lit.span(),
-            Self::Block(_, braces) => braces.span.join(),
-            Self::Bracket(_, brackets) => brackets.span.join(),
+            Self::Block { braces, .. } => braces.span.join(),
+            Self::Bracket { brackets, .. } => brackets.span.join(),
         }
     }
 }
@@ -90,9 +134,9 @@ mod tests {
     impl Value {
         pub fn is_lit(&self) -> bool { matches!(self, Self::Lit(_)) }
 
-        pub fn is_block(&self) -> bool { matches!(self, Self::Block(..)) }
+        pub fn is_block(&self) -> bool { matches!(self, Self::Block { .. }) }
 
-        pub fn is_bracketed(&self) -> bool { matches!(self, Self::Bracket(..)) }
+        pub fn is_bracketed(&self) -> bool { matches!(self, Self::Bracket { .. }) }
     }
 
     impl ValueKind {

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -251,7 +251,7 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
         Attr::Spread(spread) => {
             abort!(
                 spread.span(),
-                "spread attributes not supported on components"
+                "spread attributes not supported on components/slots"
             );
         }
         Attr::Directive(dir) => match dir {

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -475,7 +475,7 @@ fn component_classes_to_method(classes: Vec<(syn::LitStr, TokenStream)>) -> Opti
             #classes_array
                 .iter()
                 .flatten() // remove None
-                .cloned() // turn &&str to 7str
+                .cloned() // turn &&str to &str
                 .collect::<Vec<&str>>()
                 .join(" ")
         };

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -256,28 +256,19 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
         }
         Attr::Directive(dir) => match dir {
             DirectiveAttr::On(o) => {
-                if IS_SLOT {
-                    abort!(o.full_span(), "`on:` not supported on slots");
-                } else {
-                    event_listeners.extend(component_event_listener_tokens(o));
-                }
+                IS_SLOT.then(|| abort!(o.full_span(), "`on:` not supported on slots"));
+                event_listeners.extend(component_event_listener_tokens(o));
             }
             // TODO: seems like attr: could be supported on slots, but #[prop(attrs)] isn't
             // supported. allow them if they are updated in the future.
             DirectiveAttr::Attr(a) => {
-                if IS_SLOT {
-                    abort!(a.full_span(), "`attr:` not supported on slots");
-                } else {
-                    dyn_attrs.push(a);
-                }
+                IS_SLOT.then(|| abort!(a.full_span(), "`attr:` not supported on slots"));
+                dyn_attrs.push(a);
             }
             DirectiveAttr::Clone(c) => clones.extend(component_clone_tokens(c)),
             DirectiveAttr::Use(u) => {
-                if IS_SLOT {
-                    abort!(u.full_span(), "`use:` not supported on slots");
-                } else {
-                    use_directives.push(u);
-                }
+                IS_SLOT.then(|| abort!(u.full_span(), "`use:` not supported on slots"));
+                use_directives.push(u);
             }
             DirectiveAttr::Class(c) => {
                 dyn_classes.push((c.key().clone(), c.value().to_token_stream()));

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -17,7 +17,7 @@ use crate::ast::{
         selector::{SelectorShorthand, SelectorShorthands},
         spread_attrs::SpreadAttr,
     },
-    Attr, Element, KebabIdent, NodeChild, Tag, TagKind,
+    Attr, Element, KebabIdent, NodeChild, Tag,
 };
 
 /// Converts an xml (like html, svg or math) element to tokens.
@@ -73,7 +73,7 @@ pub fn xml_to_tokens(element: &Element) -> Option<TokenStream> {
     for a in element.attrs().iter() {
         match a {
             Attr::Kv(attr) => attrs.extend(xml_kv_attribute_tokens(attr)),
-            Attr::Directive(dir) => directives.extend(xml_directive_tokens(element, dir)),
+            Attr::Directive(dir) => directives.extend(xml_directive_tokens(dir)),
             Attr::Spread(spread) => spread_attrs.extend(xml_spread_tokens(spread)),
         }
     }
@@ -132,7 +132,7 @@ fn xml_kv_attribute_tokens(attr: &KvAttr) -> TokenStream {
     }
 }
 
-fn xml_directive_tokens(element: &Element, directive: &DirectiveAttr) -> TokenStream {
+fn xml_directive_tokens(directive: &DirectiveAttr) -> TokenStream {
     match directive {
         DirectiveAttr::Class(c) => {
             let (dir, name, value) = c.explode();
@@ -153,16 +153,8 @@ fn xml_directive_tokens(element: &Element, directive: &DirectiveAttr) -> TokenSt
             quote! { .#dir(::leptos::ev::#ev, #value) }
         }
         DirectiveAttr::Use(u) => use_directive_to_method(u),
-        DirectiveAttr::Attr(a) => abort_not_supported(
-            &element.tag().kind(),
-            a.full_span(),
-            directive::Attr::dir_name(),
-        ),
-        DirectiveAttr::Clone(c) => abort_not_supported(
-            &element.tag().kind(),
-            c.full_span(),
-            directive::Attr::dir_name(),
-        ),
+        DirectiveAttr::Attr(a) => abort!(a.full_span(), "`attr:` not supported on elements"),
+        DirectiveAttr::Clone(c) => abort!(c.full_span(), "`clone:` not supported on elements"),
     }
 }
 
@@ -194,6 +186,9 @@ pub fn child_methods_tokens<'a>(children: impl Iterator<Item = &'a NodeChild>) -
 ///
 /// Returns `None` if `self.tag` is not a `Component`.
 ///
+/// The const generic switches between parsing a slot and regular leptos
+/// component, as the two implementations are very similar.
+///
 /// Example builder expansion of a component:
 /// ```ignore
 /// leptos::component_view(
@@ -217,7 +212,8 @@ pub fn child_methods_tokens<'a>(children: impl Iterator<Item = &'a NodeChild>) -
 /// #[component]
 /// pub fn Com(num: u32, text: String, children: Children) -> impl IntoView { ... }
 /// ```
-pub fn component_to_tokens(element: &Element) -> Option<TokenStream> {
+#[allow(clippy::too_many_lines)]
+pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<TokenStream> {
     let Tag::Component(ident, generics) = element.tag() else {
         return None;
     };
@@ -250,36 +246,50 @@ pub fn component_to_tokens(element: &Element) -> Option<TokenStream> {
         };
     }
 
-    for a in element.attrs().iter() {
-        match a {
-            Attr::Kv(attr) => attrs.extend(component_kv_attribute_tokens(attr)),
-            Attr::Spread(spread) => {
-                abort!(
-                    spread.span(),
-                    "spread attributes not supported on components"
-                );
-            }
-            Attr::Directive(dir) => match dir {
-                DirectiveAttr::On(o) => event_listeners.extend(component_event_listener_tokens(o)),
-                DirectiveAttr::Attr(a) => dyn_attrs.push(a),
-                DirectiveAttr::Clone(c) => clones.extend(component_clone_tokens(c)),
-                DirectiveAttr::Use(u) => use_directives.push(u),
-                DirectiveAttr::Class(c) => {
-                    dyn_classes.push((c.key().clone(), c.value().to_token_stream()));
-                }
-                DirectiveAttr::Style(s) => abort_not_supported(
-                    &element.tag().kind(),
-                    s.full_span(),
-                    directive::Style::dir_name(),
-                ),
-                DirectiveAttr::Prop(p) => abort_not_supported(
-                    &element.tag().kind(),
-                    p.full_span(),
-                    directive::Prop::dir_name(),
-                ),
-            },
+    element.attrs().iter().for_each(|a| match a {
+        Attr::Kv(attr) => attrs.extend(component_kv_attribute_tokens(attr)),
+        Attr::Spread(spread) => {
+            abort!(
+                spread.span(),
+                "spread attributes not supported on components"
+            );
         }
-    }
+        Attr::Directive(dir) => match dir {
+            DirectiveAttr::On(o) => {
+                if IS_SLOT {
+                    abort!(o.full_span(), "`on:` not supported on slots");
+                } else {
+                    event_listeners.extend(component_event_listener_tokens(o));
+                }
+            }
+            // TODO: seems like attr: could be supported on slots, but #[prop(attrs)] isn't
+            // supported. allow them if they are updated in the future.
+            DirectiveAttr::Attr(a) => {
+                if IS_SLOT {
+                    abort!(a.full_span(), "`attr:` not supported on slots");
+                } else {
+                    dyn_attrs.push(a);
+                }
+            }
+            DirectiveAttr::Clone(c) => clones.extend(component_clone_tokens(c)),
+            DirectiveAttr::Use(u) => {
+                if IS_SLOT {
+                    abort!(u.full_span(), "`use:` not supported on slots");
+                } else {
+                    use_directives.push(u);
+                }
+            }
+            DirectiveAttr::Class(c) => {
+                dyn_classes.push((c.key().clone(), c.value().to_token_stream()));
+            }
+            DirectiveAttr::Style(s) => {
+                abort!(s.full_span(), "`style:` not supported on components/slots");
+            }
+            DirectiveAttr::Prop(p) => {
+                abort!(p.full_span(), "`prop:` not supported on components/slots");
+            }
+        },
+    });
 
     // convert the collected info into tokens //
 
@@ -304,26 +314,42 @@ pub fn component_to_tokens(element: &Element) -> Option<TokenStream> {
     // if attributes are missing, an error is made in `.build()` by the component
     // builder.
     let build = quote_spanned!(ident.span()=> .build());
-    // `unreachable_code` warning is generated in both of these
-    let component_view = quote_spanned!(ident.span()=> ::leptos::component_view);
-    let component_props_builder = quote_spanned!(ident.span()=> ::leptos::component_props_builder);
 
-    Some(quote! {
-        #component_view(
-            &#ident,
-            #component_props_builder(&#ident #generics)
+    if IS_SLOT {
+        // `unreachable_code` warning is generated at .into
+        let into = quote_spanned!(ident.span()=> .into());
+        Some(quote! {
+            #ident #generics::builder()
                 #attrs
                 #dyn_classes
                 #selector_ids
                 #children
-                #slot_children
                 #build
-                #dyn_attrs
-            )
-        .into_view()
-        #(#use_directives)*
-        #event_listeners
-    })
+                #into
+        })
+    } else {
+        // `unreachable_code` warning is generated in both of these
+        let component_view = quote_spanned!(ident.span()=> ::leptos::component_view);
+        let component_props_builder =
+            quote_spanned!(ident.span()=> ::leptos::component_props_builder);
+
+        Some(quote! {
+            #component_view(
+                &#ident,
+                #component_props_builder(&#ident #generics)
+                    #attrs
+                    #dyn_classes
+                    #selector_ids
+                    #children
+                    #slot_children
+                    #build
+                    #dyn_attrs
+                )
+            .into_view()
+            #(#use_directives)*
+            #event_listeners
+        })
+    }
 }
 
 fn component_kv_attribute_tokens(attr: &KvAttr) -> TokenStream {
@@ -436,6 +462,29 @@ fn dyn_attrs_to_methods(dyn_attrs: &[&directive::Attr]) -> Option<TokenStream> {
     })
 }
 
+// special attributes on components that add to a special set of props //
+
+/// Adds potentially reactive classes to the `class` attribute of a component.
+///
+/// If no classes are reactive, a static string will be passed in. Otherwise,
+/// the string is constructed and updated at runtime, which may have performance
+/// drawbacks as the entire prop is updated if one signal changes.
+///
+/// The intended use is as follows:
+/// ```ignore
+/// // TODO: use prop(optional) when Default added to TextProp
+/// #[component]
+/// fn TakesClasses(#[prop(into, default="".into())] class: TextProp) -> impl IntoView {}
+///
+/// let signal = RwSignal::new(true);
+///
+/// mview! {
+///     TakesClasses.class-1.another-class class:reactive={signal};
+/// }
+/// ```
+///
+/// For now, what is passed in to `{signal}` must be something that impls `Fn()
+/// -> bool`, it cannot just be a `bool`.
 fn component_classes_to_method(classes: Vec<(syn::LitStr, TokenStream)>) -> Option<TokenStream> {
     if classes.is_empty() {
         return None;
@@ -487,6 +536,9 @@ fn component_classes_to_method(classes: Vec<(syn::LitStr, TokenStream)>) -> Opti
     }
 }
 
+/// Adds a list of strings to the `id` prop of a component.
+///
+/// IDs should not be changed reactively, so it is not supported.
 fn component_ids_to_method(ids: Vec<syn::LitStr>) -> Option<TokenStream> {
     if ids.is_empty() {
         return None;
@@ -553,91 +605,10 @@ pub fn children_fragment_tokens<'a>(
     }
 }
 
-/// Aborts with an appropriate message when a directive is not supported.
-fn abort_not_supported(tag: &TagKind, span: Span, dir_name: &str) -> ! {
-    let suffix = match tag {
-        TagKind::Html => "html elements",
-        TagKind::Component => "components",
-        TagKind::Svg => "svgs",
-        TagKind::Math => "math elements",
-        TagKind::WebComponent => "web components",
-    };
-    abort!(
-        span,
-        "directive {} is not supported on {}",
-        dir_name,
-        suffix
-    )
-}
-
-/// Expands a slot.
-///
-/// Roughly, `slot:Tab label="aaa" { "child" }` expands to:
-///
-/// ```ignore
-/// Tab::builder()
-///     .label("aaa")
-///     // same as component_children_tokens
-///     .children(ToChildren::to_children(move || {
-///         Fragment::lazy(|| {
-///            vec![{ "child" }.into_view()]
-///         })
-///      })
-///     .build()
-///     .into()
-/// ```
-///
-/// # Aborts
-/// Aborts if `element` is not a component.
-pub fn slot_to_tokens(element: &Element) -> TokenStream {
-    if !element.selectors().is_empty() {
-        abort!(
-            element.selectors()[0].span(),
-            "selectors are not supported on slots"
-        );
-    };
-
-    let Tag::Component(ident, generics) = element.tag() else {
-        abort!(element.tag().span(), "slots must be components")
-    };
-    let mut attrs = TokenStream::new();
-    let mut clones = TokenStream::new();
-
-    for a in element.attrs().iter() {
-        match a {
-            Attr::Kv(kv) => attrs.extend(component_kv_attribute_tokens(kv)),
-            Attr::Directive(d) => match d {
-                DirectiveAttr::Clone(c) => {
-                    clones.extend(component_clone_tokens(c));
-                }
-                _ => abort!(
-                    d.span(),
-                    "only `clone:` directives are not supported on slots"
-                ),
-            },
-            Attr::Spread(s) => abort!(s.span(), "spread attrs are not supported on slots"),
-        };
-    }
-
-    // TODO: how does slots in slots work
-    let children = element.children().map(|children| {
-        component_children_tokens(
-            children.element_children(),
-            element.children_args(),
-            &clones,
-        )
-    });
-
-    quote! {
-        #ident #generics::builder()
-            #attrs
-            #children
-            .build()
-            .into()
-    }
-}
-
 #[allow(clippy::doc_markdown)]
+/// Converts a list of slots to a bunch of methods to be called on the parent
+/// component.
+///
 /// The iterator must have only elements that are slots.
 ///
 /// Slots are expanded from:
@@ -667,7 +638,8 @@ fn slots_to_tokens<'a>(children: impl Iterator<Item = &'a Element>) -> TokenStre
     for el in children {
         let component_name = el.tag().ident();
 
-        let slot_component = slot_to_tokens(el);
+        let slot_component =
+            component_to_tokens::<true>(el).expect("all children should be slot components");
         slot_children
             .entry(component_name)
             .or_default()

--- a/leptos-mview-core/src/span.rs
+++ b/leptos-mview-core/src/span.rs
@@ -17,7 +17,7 @@ pub fn join(s1: Span, s2: Span) -> Span { s1.join(s2).unwrap_or(s1) }
 /// putting it in a block is the easiest way.
 pub fn color_all(spans: impl IntoIterator<Item = Span>) -> impl Iterator<Item = TokenStream> {
     spans.into_iter().map(|span| {
-        let ident = syn::Ident::new("_", span);
+        let ident = syn::Ident::new("__x", span);
         quote! { let #ident = (); }
     })
 }

--- a/leptos-mview-core/src/span.rs
+++ b/leptos-mview-core/src/span.rs
@@ -1,6 +1,7 @@
 //! Mini helper functions for working with spans.
 
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
 
 /// Tries to join two spans together, returning just the first span if
 /// unable to join.
@@ -8,3 +9,15 @@ use proc_macro2::Span;
 /// The spans are unable to join if the user is not on nightly or the spans
 /// are in different files.
 pub fn join(s1: Span, s2: Span) -> Span { s1.join(s2).unwrap_or(s1) }
+
+/// Gives each span of `spans` the color of a variable.
+///
+/// Returns an iterator of [`TokenStream`]s that need to be expanded to
+/// somewhere in the macro. Each [`TokenStream`] contains `let _ = ();`, so
+/// putting it in a block is the easiest way.
+pub fn color_all(spans: impl IntoIterator<Item = Span>) -> impl Iterator<Item = TokenStream> {
+    spans.into_iter().map(|span| {
+        let ident = syn::Ident::new("_", span);
+        quote! { let #ident = (); }
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ fn MyComponent() -> impl IntoView {
                 blocking
             |db_info| {
                 p { "Things found: " strong { {*db_info} } "!" }
-                p { "Is bad: " [red_input().to_string()] }
+                p { "Is bad: " f["{}", red_input()] }
             }
         }
     }
@@ -89,8 +89,9 @@ fn MyComponent() -> impl IntoView {
             |db_info| {
                 p { "Things found: " strong { {*db_info} } "!" }
                 // bracketed expansion works in children too!
-                //             {move || red_input().to_string()}
-                p { "Is bad: " [red_input().to_string()] }
+                // this one also has a special prefix to add `format!` into the expansion!
+                //    {move || format!("{}", red_input()}
+                p { "Is bad: " f["{}", red_input()] }
             }
         }
     }
@@ -295,6 +296,9 @@ There are (currently) 3 main types of values you can pass in:
         }
         # ;
         ```
+
+The bracketed values can also have some special prefixes for even more common shortcuts!
+- Currently, the only one is `f` - e.g. `f["{:.2}", stuff()]`. Adding an `f` will add `format!` into the closure. This is equivalent to `[format!("{:.2}", stuff())]` or `{move || format!("{:.2}", stuff())}`.
 
 ## Attributes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,8 @@ mview! {
 
 [Slots](https://docs.rs/leptos/latest/leptos/attr.slot.html) ([another example](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs)) are supported by prefixing the struct with `slot:` inside the parent's children.
 
+The name of the parameter in the component function must be the same as the slot's name, in snake case.
+
 Using the slots defined by the [`SlotIf` example linked](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs):
 ```
 use leptos::*;
@@ -392,6 +394,62 @@ mview! {
 }
 # ;
 ```
+
+### Special Attributes
+
+There are a few special attributes you can put on your component to emulate some features only available on HTML elements.
+
+If a component has a `class` attribute, the classes using the selector syntax `.some-class` and dynamic classes `class:thing={signal}` can be passed in!
+
+```
+# use leptos::*; use leptos_mview::mview;
+#[component]
+// the `class` parameter should have these attributes and type to work properly
+fn TakesClasses(#[prop(into, default="".into())] class: TextProp) -> impl IntoView {
+    mview! {
+        // use the f[] value feature to have an existing class + any extras passed in
+        div class=f["my-component {}", class.get()] { "..." }
+    }
+}
+
+// <div class="my-component extra-class">
+mview! {
+    TakesClasses.extra-class;
+};
+```
+
+It is suggested to only pass in static classes (i.e. with selectors or just a plain `class="..."`), as using dynamic classes needs to construct a new string every time any of the signals change; dynamic classes are supported if you want them though.
+
+```ignore
+let signal = RwSignal::new(true);
+// <div class="my-component always-has-this special">
+mview! {
+    TakesClasses.always-has-this class:special={signal};
+}
+signal.set(false);
+// becomes <div class="my-component always-has-this">
+```
+
+There is one small difference from the `class:` syntax on HTML elements: the value  passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
+
+This is also supported with an `id` attribute to forward `#my-id`, though not reactively.
+```
+# use leptos::*; use leptos_mview::mview;
+#[component]
+// the `id` parameter should have these attributes and type to work properly
+fn TakesIds(#[prop(optional)] id: &'static str) -> impl IntoView {
+    mview! {
+        div {id} { "..." }
+    }
+}
+
+// <div id="my-unique-id">
+mview! {
+    TakesIds #my-unique-id;
+}
+```
+
+This is also supported on slots by having a `class` and `id` field with the same attributes and types as the components above.
 
 ## Children
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,8 @@ mview! {
 # ;
 ```
 
+Classes/ids created with the selector syntax can be mixed with the attribute `class="..."` and directive `class:a-class={signal}` as well.
+
 ## Slots
 
 [Slots](https://docs.rs/leptos/latest/leptos/attr.slot.html) ([another example](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs)) are supported by prefixing the struct with `slot:` inside the parent's children.
@@ -406,8 +408,8 @@ If a component has a `class` attribute, the classes using the selector syntax `.
 // the `class` parameter should have these attributes and type to work properly
 fn TakesClasses(#[prop(into, default="".into())] class: TextProp) -> impl IntoView {
     mview! {
-        // use the f[] value feature to have an existing class + any extras passed in
-        div class=f["my-component {}", class.get()] { "..." }
+        // "my-component" will always be present, extra classes passed in will also be added
+        div.my-component class=[class.get()] { "..." }
     }
 }
 
@@ -429,7 +431,7 @@ signal.set(false);
 // becomes <div class="my-component always-has-this">
 ```
 
-There is one small difference from the `class:` syntax on HTML elements: the value  passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
+There is one small difference from the `class:` syntax on HTML elements: the value passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
 
 This is also supported with an `id` attribute to forward `#my-id`, though not reactively.
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,7 +531,7 @@ Please feel free to make a PR/issue if you have feature ideas/bugs to report/fee
 
 ## Extra feature ideas
 
-- [ ] [Extending `class` attribute support](https://github.com/leptos-rs/leptos/issues/1492)
+- [x] [Extending `class` attribute support](https://github.com/leptos-rs/leptos/issues/1492)
 - [ ] [SSR optimisation](https://github.com/leptos-rs/leptos/issues/1492#issuecomment-1664675672) (potential `delegate` feature that transforms this macro into a `leptos::view!` macro call as well?)
 - [x] Support slots
  */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,14 +383,13 @@ mview! {
 # ;
 ```
 
-The `class` and `style` directives also support using string literals, for more complicated names or multiple classes at once.
+The `class` and `style` directives also support using string literals, for more complicated names. Make sure the string for `class:` doesn't have spaces, or it will panic!
 ```
 # use leptos::*; use leptos_mview::mview;
 let yes = move || true;
 mview! {
     div class:"complex-[class]-name"={yes}
-        style:"doesn't-exist"="white"
-        class:"class-one class-two"={yes};
+        style:"doesn't-exist"="white";
 }
 # ;
 ```
@@ -446,7 +445,7 @@ fn TakesIds(#[prop(optional)] id: &'static str) -> impl IntoView {
 // <div id="my-unique-id">
 mview! {
     TakesIds #my-unique-id;
-}
+};
 ```
 
 This is also supported on slots by having a `class` and `id` field with the same attributes and types as the components above.
@@ -471,6 +470,8 @@ mview! {
 Note that you will usually need to add a `*` before the data you are using. If you forget that, rust-analyser will tell you to dereference here: `*{monkeys}`. This is obviously invalid - put it inside the braces. (If anyone knows how to fix this, feel free to contribute!)
 
 Summary from the previous section on values in case you missed it: children can be literal strings (not bools or numbers!), blocks with Rust code inside (`{*monkeys}`), or the closure shorthand `[number() + 1]`.
+
+Children with closures are also supported on slots, add a field `children: Callback<T, View>` to use it (`T` is whatever type you want).
 
 # Extra details
 

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -75,4 +75,53 @@ fn let_patterns() {
     }
 }
 
-fn main() {}
+#[component]
+fn TakesClass(#[prop(into)] class: TextProp) -> impl IntoView {
+    mview! {
+        div class=f["takes-class {}", class.get()] {
+            "I take more classes!"
+        }
+    }
+}
+
+#[component]
+fn TakesIds(id: &'static str) -> impl IntoView {
+    mview! {
+        div {id} class="i-take-ids";
+    }
+}
+
+#[test]
+fn selectors() {
+    let r = mview! {
+        TakesClass.test1.test-2;
+    };
+
+    check_str(r, r#"<div class="takes-class test1 test-2"#)
+}
+
+// untracked signal warning... should be fine.
+#[test]
+fn class_dir() {
+    let runtime = create_runtime();
+    let yes = RwSignal::new(true);
+    let no = move || !yes();
+    let r = mview! {
+        TakesClass.test1.test-2 class:not-this={no} class:this={yes} class:"complicated"=[yes()];
+    };
+    check_str(
+        r,
+        r#"div class="takes-class test1 test-2 this complicated""#,
+    );
+
+    runtime.dispose();
+}
+
+#[test]
+fn ids() {
+    let r = mview! {
+        TakesIds #id-1 #id-number-two;
+    };
+
+    check_str(r, r#"<div id="id-1 id-number-two" class="i-take-ids""#)
+}

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -99,12 +99,11 @@ fn string_directives() {
         div
             class:"complex[class]-name"={yes}
             style:"doesn't-exist"="black"
-            class:"with spaces"=true
             class:"not-here"=false;
     };
 
     check_str(
         result,
-        r#"class="complex[class]-name with spaces" style="doesn't-exist: black;""#,
+        r#"class="complex[class]-name" style="doesn't-exist: black;""#,
     )
 }

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -107,3 +107,13 @@ fn string_directives() {
         r#"class="complex[class]-name" style="doesn't-exist: black;""#,
     )
 }
+
+#[test]
+fn mixed_class_creation() {
+    let class: TextProp = "some-class another-class".into();
+    let r = mview! {
+        div.always-here class=[class.get()];
+    };
+
+    check_str(r, r#"class="some-class another-class always-here""#);
+}

--- a/tests/ui/errors/com_builder_spans.stderr
+++ b/tests/ui/errors/com_builder_spans.stderr
@@ -150,7 +150,7 @@ error[E0283]: type annotations needed
 49 |         Await future=[async { 3 }] { "no args" }
    |         ^^^^^ cannot infer type of the type parameter `VF` declared on the function `Await`
    |
-   = note: multiple `impl`s satisfying `_: ToChildren<{closure@$DIR/tests/ui/errors/com_builder_spans.rs:48:9: 50:6}>` found in the `leptos` crate:
+   = note: multiple `impl`s satisfying `_: ToChildren<{closure@$DIR/tests/ui/errors/com_builder_spans.rs:49:38: 49:47}>` found in the `leptos` crate:
            - impl<F> ToChildren<F> for Box<(dyn FnMut() -> Fragment + 'static)>
              where <F as FnOnce<()>>::Output == Fragment, F: FnMut<()>, F: 'static;
            - impl<F> ToChildren<F> for Box<(dyn FnOnce() -> Fragment + 'static)>

--- a/tests/ui/errors/com_dyn_classes.rs
+++ b/tests/ui/errors/com_dyn_classes.rs
@@ -1,0 +1,47 @@
+use leptos::*;
+use leptos_mview::mview;
+
+#[component]
+fn AComponent(
+    #[prop(into, default="".into())] class: TextProp,
+    #[prop(optional)] id: &'static str,
+) -> impl IntoView {
+    mview! {
+        div class=f["my-class {}", class.get()] {id};
+    }
+}
+
+fn missing_closure() {
+    _ = mview! {
+        AComponent class:red=true;
+    };
+}
+
+fn incorrect_type() {
+    _ = mview! {
+        AComponent class:red=["not this"];
+    };
+}
+
+#[component]
+fn Nothing() -> impl IntoView {}
+
+fn no_attribute_reactive() {
+    _ = mview! {
+        Nothing class:red=[true];
+    };
+}
+
+fn no_attribute_static() {
+    _ = mview! {
+        Nothing.red;
+    };
+}
+
+fn no_attribute_id() {
+    _ = mview! {
+        Nothing #unique;
+    };
+}
+
+fn main() {}

--- a/tests/ui/errors/com_dyn_classes.stderr
+++ b/tests/ui/errors/com_dyn_classes.stderr
@@ -1,0 +1,38 @@
+error[E0618]: expected function, found `bool`
+  --> tests/ui/errors/com_dyn_classes.rs:16:30
+   |
+16 |         AComponent class:red=true;
+   |                              ^^^^ call expression requires function
+
+error[E0308]: mismatched types
+  --> tests/ui/errors/com_dyn_classes.rs:22:30
+   |
+22 |         AComponent class:red=["not this"];
+   |                              ^^^^^^^^^^^^
+   |                              |
+   |                              expected `bool`, found `&str`
+   |                              arguments to this function are incorrect
+   |
+note: method defined here
+  --> $RUST/core/src/bool.rs
+   |
+   |     pub fn then_some<T>(self, t: T) -> Option<T> {
+   |            ^^^^^^^^^
+
+error[E0599]: no method named `class` found for struct `EmptyPropsBuilder` in the current scope
+  --> tests/ui/errors/com_dyn_classes.rs:31:23
+   |
+31 |         Nothing class:red=[true];
+   |                       ^^^ method not found in `EmptyPropsBuilder`
+
+error[E0599]: no method named `class` found for struct `EmptyPropsBuilder` in the current scope
+  --> tests/ui/errors/com_dyn_classes.rs:37:17
+   |
+37 |         Nothing.red;
+   |                 ^^^ method not found in `EmptyPropsBuilder`
+
+error[E0599]: no method named `id` found for struct `EmptyPropsBuilder` in the current scope
+  --> tests/ui/errors/com_dyn_classes.rs:43:18
+   |
+43 |         Nothing #unique;
+   |                  ^^^^^^ method not found in `EmptyPropsBuilder`

--- a/tests/ui/errors/slot_builder_spans.rs
+++ b/tests/ui/errors/slot_builder_spans.rs
@@ -1,0 +1,74 @@
+//! Testing that there are no errors that cause the entire macro to error (i.e.
+//! call-site error).
+//! 
+//! This file is for testing on the slot itself, see `com_builder_spans` for testing on components.
+
+use leptos::*;
+use leptos_mview::mview;
+
+#[slot]
+struct SChildren {
+    an_attr: i32,
+    children: ChildrenFn,
+}
+
+#[component]
+fn TakesSChildren(s_children: SChildren) -> impl IntoView { let _ = s_children; }
+
+fn missing_args() {
+    _ = mview! {
+        TakesSChildren {
+            slot:SChildren { "hi" }
+        }
+    };
+}
+
+fn incorrect_arg_value() {
+    _ = mview! {
+        TakesSChildren { slot:SChildren an_attr="no" { "what" } }
+    };
+}
+
+fn incorrect_closure_to_children() {
+    let s = String::new();
+    _ = mview! {
+        TakesSChildren {
+            slot:SChildren an_attr=1 |s| { "this is " {s} }
+        }
+    };
+}
+
+#[slot]
+struct SNoChildren {
+    an_attr: i32,
+}
+
+#[component]
+fn TakesSNoChildren(s_no_children: SNoChildren) -> impl IntoView { let _ = s_no_children; }
+
+fn incorrect_children() {
+    _ = mview! {
+        TakesSNoChildren {
+            slot:SNoChildren an_attr=5 { "hey!" }
+        }
+    };
+}
+
+#[slot]
+struct SClosureChildren {
+    children: Callback<i32, View>,
+}
+
+#[component]
+fn TakesSClosureChildren(s_closure_children: SClosureChildren) -> impl IntoView { let _ = s_closure_children; }
+
+fn missing_closure_to_children() {
+    _ = mview! {
+        TakesSClosureChildren {
+            slot:SClosureChildren { "hey!" }
+        }
+    };
+}
+
+
+fn main() {}

--- a/tests/ui/errors/slot_builder_spans.stderr
+++ b/tests/ui/errors/slot_builder_spans.stderr
@@ -1,0 +1,93 @@
+warning: use of deprecated method `SChildrenBuilder::<((), __children)>::build`: Missing required field an_attr
+  --> tests/ui/errors/slot_builder_spans.rs:21:18
+   |
+21 |             slot:SChildren { "hi" }
+   |                  ^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error[E0061]: this method takes 1 argument but 0 arguments were supplied
+  --> tests/ui/errors/slot_builder_spans.rs:21:18
+   |
+21 |             slot:SChildren { "hi" }
+   |                  ^^^^^^^^^ an argument of type `SChildrenBuilder_Error_Missing_required_field_an_attr` is missing
+   |
+note: method defined here
+  --> tests/ui/errors/slot_builder_spans.rs:9:1
+   |
+9  | #[slot]
+   | ^^^^^^^
+   = note: this error originates in the derive macro `::leptos::typed_builder_macro::TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide the argument
+   |
+21 |             slot:SChildren(/* SChildrenBuilder_Error_Missing_required_field_an_attr */) { "hi" }
+   |                           +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: unreachable call
+  --> tests/ui/errors/slot_builder_spans.rs:21:18
+   |
+19 |       _ = mview! {
+   |  _________-
+20 | |         TakesSChildren {
+21 | |             slot:SChildren { "hi" }
+   | |                  ^^^^^^^^^ unreachable call
+22 | |         }
+23 | |     };
+   | |_____- any code following this expression is unreachable
+   |
+   = note: `#[warn(unreachable_code)]` on by default
+
+error[E0308]: mismatched types
+  --> tests/ui/errors/slot_builder_spans.rs:28:49
+   |
+28 |         TakesSChildren { slot:SChildren an_attr="no" { "what" } }
+   |                                         ------- ^^^^ expected `i32`, found `&str`
+   |                                         |
+   |                                         arguments to this method are incorrect
+   |
+note: method defined here
+  --> tests/ui/errors/slot_builder_spans.rs:11:5
+   |
+11 |     an_attr: i32,
+   |     ^^^^^^^-----
+
+error[E0308]: mismatched types
+  --> tests/ui/errors/slot_builder_spans.rs:36:38
+   |
+36 |             slot:SChildren an_attr=1 |s| { "this is " {s} }
+   |                                      ^^^ expected `Rc<dyn Fn() -> Fragment>`, found closure
+   |
+   = note: expected struct `Rc<(dyn std::ops::Fn() -> Fragment + 'static)>`
+             found closure `{closure@$DIR/tests/ui/errors/slot_builder_spans.rs:36:38: 36:41}`
+
+error[E0599]: no method named `children` found for struct `SNoChildrenBuilder` in the current scope
+  --> tests/ui/errors/slot_builder_spans.rs:52:42
+   |
+41 |   #[slot]
+   |   ------- method `children` not found for this struct
+...
+50 |       _ = mview! {
+   |  _________-
+51 | |         TakesSNoChildren {
+52 | |             slot:SNoChildren an_attr=5 { "hey!" }
+   | |                                         -^^^^^^ method not found in `SNoChildrenBuilder<((i32,),)>`
+   | |_________________________________________|
+   |
+
+error[E0277]: the trait bound `leptos::Callback<i32, leptos::View>: ToChildren<{closure@$DIR/tests/ui/errors/slot_builder_spans.rs:68:37: 68:43}>` is not satisfied
+  --> tests/ui/errors/slot_builder_spans.rs:68:37
+   |
+66 |       _ = mview! {
+   |  _________-
+67 | |         TakesSClosureChildren {
+68 | |             slot:SClosureChildren { "hey!" }
+   | |                                     ^^^^^^ the trait `ToChildren<{closure@$DIR/tests/ui/errors/slot_builder_spans.rs:68:37: 68:43}>` is not implemented for `leptos::Callback<i32, leptos::View>`
+69 | |         }
+70 | |     };
+   | |_____- required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `ToChildren<F>`:
+             Box<(dyn std::ops::Fn() -> Fragment + 'static)>
+             Box<(dyn FnMut() -> Fragment + 'static)>
+             Box<(dyn FnOnce() -> Fragment + 'static)>
+             Rc<(dyn std::ops::Fn() -> Fragment + 'static)>

--- a/tests/ui/errors/slot_unsupported_dirs.rs
+++ b/tests/ui/errors/slot_unsupported_dirs.rs
@@ -1,0 +1,44 @@
+use leptos::*;
+use leptos_mview::mview;
+
+#[slot]
+struct Nothing {}
+
+#[component]
+fn TakesNothing(nothing: Nothing) -> impl IntoView { let _ = nothing; }
+
+fn try_bad_dirs() {
+    let attrs: Vec<(&'static str, Attribute)> = Vec::new();
+    let _spread = mview! {
+        TakesNothing {
+            slot:Nothing {..attrs};
+        }
+    };
+
+    let _on = mview! {
+        TakesNothing {
+            slot:Nothing on:click={|_| ()};
+        }
+    };
+
+    let _attr = mview! {
+        TakesNothing {
+            slot:Nothing attr:something="something";
+        }
+    };
+
+    fn a_directive(_el: HtmlElement<html::AnyElement>) {}
+    let _use = mview! {
+        TakesNothing {
+            slot:Nothing use:a_directive;
+        }
+    };
+
+    let _prop = mview! {
+        TakesNothing {
+            slot:Nothing prop:value="1";
+        }
+    };
+}
+
+fn main() {}

--- a/tests/ui/errors/slot_unsupported_dirs.stderr
+++ b/tests/ui/errors/slot_unsupported_dirs.stderr
@@ -1,0 +1,29 @@
+error: spread attributes not supported on components/slots
+  --> tests/ui/errors/slot_unsupported_dirs.rs:14:26
+   |
+14 |             slot:Nothing {..attrs};
+   |                          ^^^^^^^^^
+
+error: `on:` not supported on slots
+  --> tests/ui/errors/slot_unsupported_dirs.rs:20:26
+   |
+20 |             slot:Nothing on:click={|_| ()};
+   |                          ^^^^^^^^
+
+error: `attr:` not supported on slots
+  --> tests/ui/errors/slot_unsupported_dirs.rs:26:26
+   |
+26 |             slot:Nothing attr:something="something";
+   |                          ^^^^^^^^^^^^^^
+
+error: `use:` not supported on slots
+  --> tests/ui/errors/slot_unsupported_dirs.rs:33:26
+   |
+33 |             slot:Nothing use:a_directive;
+   |                          ^^^^^^^^^^^^^^^
+
+error: `prop:` not supported on components/slots
+  --> tests/ui/errors/slot_unsupported_dirs.rs:39:26
+   |
+39 |             slot:Nothing prop:value="1";
+   |                          ^^^^^^^^^^

--- a/tests/ui/errors/unsupported_attrs.rs
+++ b/tests/ui/errors/unsupported_attrs.rs
@@ -7,12 +7,6 @@ fn style_on_component() {
     };
 }
 
-fn class_on_component() {
-    mview! {
-        Component class:red={true};
-    };
-}
-
 fn prop_on_component() {
     mview! {
         Component prop:value="1";
@@ -45,12 +39,6 @@ fn clone_on_element() {
                 {notcopy.clone()}
             }
         }
-    };
-}
-
-fn sel_shorthand_on_components() {
-    mview! {
-        Component.not-working #some-id;
     };
 }
 

--- a/tests/ui/errors/unsupported_attrs.stderr
+++ b/tests/ui/errors/unsupported_attrs.stderr
@@ -1,28 +1,28 @@
-error: directive `style` is not supported on components
+error: `style:` not supported on components/slots
  --> tests/ui/errors/unsupported_attrs.rs:6:19
   |
 6 |         Component style:color="white";
   |                   ^^^^^^^^^^^
 
-error: directive `prop` is not supported on components
+error: `prop:` not supported on components/slots
   --> tests/ui/errors/unsupported_attrs.rs:12:19
    |
 12 |         Component prop:value="1";
    |                   ^^^^^^^^^^
 
-error: spread attributes not supported on components
+error: spread attributes not supported on components/slots
   --> tests/ui/errors/unsupported_attrs.rs:24:19
    |
 24 |         Component {..attrs};
    |                   ^^^^^^^^^
 
-error: directive `attr` is not supported on html elements
+error: `attr:` not supported on elements
   --> tests/ui/errors/unsupported_attrs.rs:30:15
    |
 30 |         input attr:class="no" type="text";
    |               ^^^^^^^^^^
 
-error: directive `attr` is not supported on html elements
+error: `clone:` not supported on elements
   --> tests/ui/errors/unsupported_attrs.rs:38:18
    |
 38 |             span clone:notcopy {

--- a/tests/ui/errors/unsupported_attrs.stderr
+++ b/tests/ui/errors/unsupported_attrs.stderr
@@ -4,38 +4,26 @@ error: directive `style` is not supported on components
 6 |         Component style:color="white";
   |                   ^^^^^^^^^^^
 
-error: directive `class` is not supported on components
+error: directive `prop` is not supported on components
   --> tests/ui/errors/unsupported_attrs.rs:12:19
    |
-12 |         Component class:red={true};
-   |                   ^^^^^^^^^
-
-error: directive `prop` is not supported on components
-  --> tests/ui/errors/unsupported_attrs.rs:18:19
-   |
-18 |         Component prop:value="1";
+12 |         Component prop:value="1";
    |                   ^^^^^^^^^^
 
 error: spread attributes not supported on components
-  --> tests/ui/errors/unsupported_attrs.rs:30:19
+  --> tests/ui/errors/unsupported_attrs.rs:24:19
    |
-30 |         Component {..attrs};
+24 |         Component {..attrs};
    |                   ^^^^^^^^^
 
 error: directive `attr` is not supported on html elements
-  --> tests/ui/errors/unsupported_attrs.rs:36:15
+  --> tests/ui/errors/unsupported_attrs.rs:30:15
    |
-36 |         input attr:class="no" type="text";
+30 |         input attr:class="no" type="text";
    |               ^^^^^^^^^^
 
 error: directive `attr` is not supported on html elements
-  --> tests/ui/errors/unsupported_attrs.rs:44:18
+  --> tests/ui/errors/unsupported_attrs.rs:38:18
    |
-44 |             span clone:notcopy {
+38 |             span clone:notcopy {
    |                  ^^^^^^^^^^^^^
-
-error: class/id selector shorthand is not supported on components
-  --> tests/ui/errors/unsupported_attrs.rs:53:18
-   |
-53 |         Component.not-working #some-id;
-   |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use leptos::*;
 
 #[track_caller]

--- a/tests/values.rs
+++ b/tests/values.rs
@@ -1,0 +1,20 @@
+use leptos_mview::mview;
+use utils::check_str;
+mod utils;
+
+#[test]
+fn f_value() {
+    let yes = || true;
+    let no = || false;
+    let r = mview! {
+        div aria-selected=f["{}", yes()] data-not-selected=f["{}", no()];
+    };
+
+    check_str(r, r#"<div aria-selected="true" data-not-selected="false""#);
+
+    let number = 2.12545;
+    let r = mview! {
+        input type="number" value=f["{number:.2}"];
+    };
+    check_str(r, r#"<input type="number" value="2.13""#);
+}


### PR DESCRIPTION
bunch of qol features:
- `f[...]` values as a shorthand for `[format!(...)]` or `{move || format!(...)}`
- special attributes `class` and `id` can be constructed for components with the selector or directive.
- component and slot expansion are very similar, combined into one function for sharing features
- significantly improved r-a support, there should be no more potential errors that cause the entire macro to error; all potential errors are spanned properly.