### PR TITLE
fix: replace `std::vec![]` with `<[_]>::into_vec()` for r-a support

### DIFF
--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -51,9 +51,9 @@ pub fn children_fragment_tokens<'a>(
 ) -> TokenStream {
     quote_spanned! { span=>
         ::leptos::Fragment::lazy(|| {
-            ::std::vec![
+            <[_]>::into_vec(::std::boxed::Box::new([
                 #(  ::leptos::IntoView::into_view(#children) ),*
-            ]
+            ]))
         })
     }
 }
@@ -379,9 +379,9 @@ fn slots_to_tokens<'a>(children: impl Iterator<Item = &'a Element>) -> TokenStre
                 }
             } else {
                 quote! {
-                    .#method(::std::vec![
+                    .#method(<[_]>::into_vec(::std::boxed::Box::new([
                         #(#slot_tokens),*
-                    ])
+                    ])))
                 }
             }
         })

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -288,9 +288,9 @@ pub(super) fn component_dyn_attrs_to_methods(dyn_attrs: &[&Directive]) -> Option
 
     Some(quote! {
         .#dyn_attrs_method(
-            ::std::vec![
+            <[_]>::into_vec(std::boxed::Box::new([
                 #( (#keys, ::leptos::IntoAttribute::into_attribute(#values)) ),*
-            ]
+            ]))
         )
     })
 }


### PR DESCRIPTION
fixes #13 

`mview!` can expand invalid partial expressions correctly, but some of it is expanded into `vec![...]`, which needs to match on `$expr`. This causes the partial expression to not expand enough for rust-analyzer to be able to provide autocomplete/whatever on it.