### PR TITLE
Leptos 0.7 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-mview"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["macro", "leptos", "view"]
@@ -11,7 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos-mview-macro = { path = "leptos-mview-macro", version = "0.3.2" }
+leptos-mview-macro = { path = "leptos-mview-macro", version = "0.4.0" }
 
 [dev-dependencies]
 trybuild = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ leptos-mview-macro = { path = "leptos-mview-macro", version = "0.3.2" }
 
 [dev-dependencies]
 trybuild = "1"
-leptos = { version = "0.6.12", features = ["nightly", "csr"] }
+leptos = { version = "0.7.0-rc3", features = ["csr"] }
 
 [workspace]
 members = ["leptos-mview-core", "leptos-mview-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ leptos-mview-macro = { path = "leptos-mview-macro", version = "0.3.2" }
 
 [dev-dependencies]
 trybuild = "1"
-leptos = { version = "0.7.0-rc3", features = ["csr"] }
+# needs to use ssr for some view-to-HTML features to work.
+leptos = { version = "0.7.0", features = ["ssr"] }
 
 [workspace]
 members = ["leptos-mview-core", "leptos-mview-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ leptos-mview-macro = { path = "leptos-mview-macro", version = "0.3.2" }
 [dev-dependencies]
 trybuild = "1"
 # needs to use ssr for some view-to-HTML features to work.
-leptos = { version = "0.7.0", features = ["ssr"] }
+leptos = { version = "0.7.0", features = ["ssr", "nightly"] }
+leptos-mview = { path = ".", features = ["nightly"] }
+
+[features]
+nightly = ["leptos-mview-macro/nightly"]
 
 [workspace]
 members = ["leptos-mview-core", "leptos-mview-macro"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The below are the versions with which I have tested it to be working. It is like
 | `0.1`                  | `0.5`                       |
 | `0.2`                  | `0.5`, `0.6`                |
 | `0.3`                  | `0.6`                       |
+| `0.4`                  | `0.7`                       |
+
+This crate also has a feature `"nightly"` that enables better proc-macro diagnostics (simply enables the nightly feature in proc-macro-error2. Necessary while [this pr](https://github.com/GnomedDev/proc-macro-error-2/pull/5) is not yet merged).
 
 ## Syntax details
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An alternative `view!` macro for [Leptos](https://github.com/leptos-rs/leptos/tr
 A little preview of the syntax:
 
 ```rust
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]
@@ -54,7 +54,7 @@ async fn fetch_from_db(data: String) -> usize { data.len() }
 <summary> Explanation of the example: </summary>
 
 ```rust
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]
@@ -182,7 +182,7 @@ The name of the parameter in the component function must be the same as the slot
 
 Using the slots defined by the [`SlotIf` example linked](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs):
 ```rust
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use leptos_mview::mview;
 
 #[component]
 fn MyComponent() -> impl IntoView {
-    let (value, set_value) = create_signal(String::new());
+    let (value, set_value) = signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
     mview! {
@@ -37,7 +37,7 @@ fn MyComponent() -> impl IntoView {
             fallback=[mview! { "..." }]
         {
             Await
-                future=[fetch_from_db(value())]
+                future={fetch_from_db(value())}
                 blocking
             |db_info| {
                 p { "Things found: " strong { {*db_info} } "!" }
@@ -59,7 +59,7 @@ use leptos_mview::mview;
 
 #[component]
 fn MyComponent() -> impl IntoView {
-    let (value, set_value) = create_signal(String::new());
+    let (value, set_value) = signal(String::new());
     let red_input = move || value().len() % 2 == 0;
 
     mview! {
@@ -85,7 +85,7 @@ fn MyComponent() -> impl IntoView {
             fallback=[mview! { "..." }] // `{move || mview! { "..." }}`
         { // I recommend placing children like this when attributes are multi-line
             Await
-                future=[fetch_from_db(value())]
+                future={fetch_from_db(value())}
                 blocking // expanded to `blocking=true`
             // children take arguments with a 'closure'
             // this is very different to `let:db_info` in Leptos!
@@ -109,10 +109,6 @@ async fn fetch_from_db(data: String) -> usize { data.len() }
 ## Purpose
 
 The `view!` macros in Leptos is often the largest part of a component, and can get extremely long when writing complex components. This macro aims to be as **concise** as possible, trying to **minimise unnecessary punctuation/words** and **shorten common patterns**.
-
-## Performance note
-
-Currently, the macro expands to the [builder syntax](https://github.com/leptos-rs/leptos/blob/main/docs/book/src/view/builder.md) (ish), but it has some [performance downsides](https://github.com/leptos-rs/leptos/issues/1492#issuecomment-1664675672) in SSR mode. This is expected to be fixed with the new renderer in Leptos `0.7`, so I'm not going to make this implementation.
 
 ## Compatibility
 
@@ -219,7 +215,7 @@ There are (currently) 3 main types of values you can pass in:
         input
             class="main"
             checked=true
-            madeup=3
+            data-index=3
             type={input_type}
             on:input={move |_| handle_input(1)};
     }
@@ -343,60 +339,6 @@ mview! {
 
 Note that the `use:` directive automatically calls `.into()` on its argument, consistent with behaviour from Leptos.
 
-#### Special Attributes
-
-There are a few special attributes you can put on your component to emulate some features only available on HTML elements.
-
-If a component has a `class` attribute, the classes using the selector syntax `.some-class` and dynamic classes `class:thing={signal}` can be passed in!
-
-```rust
-#[component]
-// the `class` parameter should have these attributes and type to work properly
-fn TakesClasses(#[prop(optional, into)] class: TextProp) -> impl IntoView {
-    mview! {
-        // "my-component" will always be present, extra classes passed in will also be added
-        div.my-component class=[class.get()] { "..." }
-    }
-}
-
-// <div class="my-component extra-class">
-mview! {
-    TakesClasses.extra-class;
-};
-```
-
-It is suggested to only pass in static classes (i.e. with selectors or just a plain `class="..."`), as using dynamic classes needs to construct a new string every time any of the signals change; dynamic classes are supported if you want them though.
-
-```rust
-let signal = RwSignal::new(true);
-// <div class="my-component always-has-this special">
-mview! {
-    TakesClasses.always-has-this class:special={signal};
-}
-signal.set(false);
-// becomes <div class="my-component always-has-this">
-```
-
-There is one small difference from the `class:` syntax on HTML elements: the value passed in must be an `Fn() -> bool`, it cannot just be a `bool`.
-
-This is also supported with an `id` attribute to forward `#my-id`, though not reactively.
-```rust
-#[component]
-// the `id` parameter should have these attributes and type to work properly
-fn TakesIds(#[prop(optional)] id: &'static str) -> impl IntoView {
-    mview! {
-        div {id} { "..." }
-    }
-}
-
-// <div id="my-unique-id">
-mview! {
-    TakesIds #my-unique-id;
-};
-```
-
-This is also supported on slots by having a `class` and `id` field with the same attributes and types as the components above.
-
 ### Children
 
 You may have noticed that the `let:data` prop was missing from the previous section on directive attributes!
@@ -405,7 +347,7 @@ This is replaced with a closure right before the children block. This way, you c
 ```rust
 mview! {
     Await
-        future=[async { 3 }]
+        future={async { 3 }}
     |monkeys| {
         p { {*monkeys} " little monkeys, jumping on the bed." }
     }
@@ -425,7 +367,7 @@ mview! {
 
 Summary from the previous section on values in case you missed it: children can be literal strings (not bools or numbers!), blocks with Rust code inside (`{*monkeys}`), or the closure shorthand `[number() + 1]`.
 
-Children with closures are also supported on slots, add a field `children: Callback<T, View>` to use it (`T` is whatever type you want).
+Children with closures are also supported on slots.
 
 ## Extra details
 
@@ -454,7 +396,6 @@ If an attribute shorthand has hyphens:
 
 Note the behaviour from Leptos: setting an HTML attribute to true adds the attribute with no value associated.
 ```rust
-use leptos::view;
 view! { <input type="checkbox" checked=true data-smth=true not-here=false /> }
 ```
 Becomes `<input type="checkbox" checked data-smth />`, NOT `checked="true"` or `data-smth="true"` or `not-here="false"`.

--- a/leptos-mview-core/Cargo.toml
+++ b/leptos-mview-core/Cargo.toml
@@ -13,4 +13,4 @@ readme = "README.md"
 syn = { version = "2", features = [] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error = { version = "1", default-features = false }
+proc-macro-error2 = "2"

--- a/leptos-mview-core/Cargo.toml
+++ b/leptos-mview-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-mview-core"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Main implementation of leptos-mview"

--- a/leptos-mview-core/src/ast/attribute/kv.rs
+++ b/leptos-mview-core/src/ast/attribute/kv.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Span;
-use syn::{parse::Parse, parse_quote, Token};
+use syn::{parse::Parse, Token};
 
 use crate::{
     ast::{BracedKebabIdent, KebabIdent, Value},
@@ -52,8 +52,7 @@ impl Parse for KvAttr {
                 let value = Value::parse_or_emit_err(input, eq.span);
                 (ident, value)
             } else {
-                // don't span the attribute name to the `true` or it becomes bool-colored
-                let value = Value::Lit(parse_quote!(true));
+                let value = Value::new_true();
                 (ident, value)
             }
         };

--- a/leptos-mview-core/src/ast/children.rs
+++ b/leptos-mview-core/src/ast/children.rs
@@ -1,6 +1,6 @@
 use proc_macro2::Span;
 use proc_macro_error2::emit_error;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::{
     ext::IdentExt,
     parse::{Parse, ParseStream},
@@ -25,10 +25,13 @@ pub enum NodeChild {
 
 impl ToTokens for NodeChild {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self {
-            Self::Value(v) => tokens.extend(v.into_token_stream()),
-            Self::Element(e) => tokens.extend(e.into_token_stream()),
-        }
+        let child_tokens = match self {
+            Self::Value(v) => v.into_token_stream(),
+            Self::Element(e) => e.into_token_stream(),
+        };
+        tokens.extend(quote! {
+            ::leptos::prelude::IntoRender::into_render(#child_tokens)
+        });
     }
 }
 

--- a/leptos-mview-core/src/ast/children.rs
+++ b/leptos-mview-core/src/ast/children.rs
@@ -1,5 +1,5 @@
 use proc_macro2::Span;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::ToTokens;
 use syn::{
     ext::IdentExt,

--- a/leptos-mview-core/src/ast/element.rs
+++ b/leptos-mview-core/src/ast/element.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{TokenStream, TokenTree};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},

--- a/leptos-mview-core/src/ast/ident.rs
+++ b/leptos-mview-core/src/ast/ident.rs
@@ -206,6 +206,13 @@ impl KebabIdentOrStr {
             }
         }
     }
+
+    pub fn to_unspanned_string(&self) -> String {
+        match self {
+            Self::KebabIdent(kebab_ident) => kebab_ident.repr().to_string(),
+            Self::Str(lit_str) => lit_str.value(),
+        }
+    }
 }
 
 impl Parse for KebabIdentOrStr {

--- a/leptos-mview-core/src/ast/ident.rs
+++ b/leptos-mview-core/src/ast/ident.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::{quote, ToTokens};
 use syn::{
     ext::IdentExt,

--- a/leptos-mview-core/src/ast/tag.rs
+++ b/leptos-mview-core/src/ast/tag.rs
@@ -39,13 +39,22 @@ impl Tag {
     /// Returns the [`Span`] of the tag identifier.
     ///
     /// Component generics are not included in this span.
-    ///
-    /// Use the [`Tag::ident`] function if the identifier itself is required.
     pub fn span(&self) -> Span {
         match self {
             Self::Html(ident) | Self::Svg(ident) | Self::Math(ident) => ident.span(),
             Self::WebComponent(ident) => ident.span(),
             Self::Component(path) => path.span(),
+        }
+    }
+
+    /// Returns the [`TagKind`] of this tag.
+    pub fn kind(&self) -> TagKind {
+        match self {
+            Tag::Html(_) => TagKind::Html,
+            Tag::Component(_) => TagKind::Component,
+            Tag::Svg(_) => TagKind::Svg,
+            Tag::Math(_) => TagKind::Math,
+            Tag::WebComponent(_) => TagKind::WebComponent,
         }
     }
 }

--- a/leptos-mview-core/src/ast/value.rs
+++ b/leptos-mview-core/src/ast/value.rs
@@ -4,6 +4,7 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     ext::IdentExt,
     parse::{Parse, ParseStream},
+    parse_quote,
     spanned::Spanned,
 };
 
@@ -148,6 +149,9 @@ impl Value {
             }
         }
     }
+
+    /// Constructs self as a literal `true` with no span.
+    pub fn new_true() -> Self { Self::Lit(parse_quote!(true)) }
 }
 
 #[cfg(test)]

--- a/leptos-mview-core/src/ast/value.rs
+++ b/leptos-mview-core/src/ast/value.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::{emit_error, Diagnostic};
+use proc_macro_error2::{emit_error, Diagnostic};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     ext::IdentExt,
@@ -130,7 +130,7 @@ impl Value {
             // incomplete typing; place a MissingValueAfterEq and continue
             let error = Diagnostic::spanned(
                 span,
-                proc_macro_error::Level::Error,
+                proc_macro_error2::Level::Error,
                 "expected value after =".to_string(),
             );
             // if the token after the `=` is an ident, perhaps the user forgot to wrap in

--- a/leptos-mview-core/src/error_ext.rs
+++ b/leptos-mview-core/src/error_ext.rs
@@ -3,7 +3,7 @@
 //!
 //! A simplified version of the extension traits have been added here.
 
-use proc_macro_error::{abort, emit_error};
+use proc_macro_error2::{abort, emit_error};
 
 pub trait ResultExt {
     type Ok;

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -7,12 +7,12 @@ use std::collections::HashMap;
 
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::emit_error;
-use quote::{quote, quote_spanned, ToTokens};
-use syn::{ext::IdentExt, spanned::Spanned};
+use quote::{quote, quote_spanned};
+use syn::{ext::IdentExt, parse_quote, parse_quote_spanned, spanned::Spanned};
 
 use crate::ast::{
     attribute::{directive::Directive, selector::SelectorShorthand},
-    Attr, Element, KebabIdent, KebabIdentOrStr, NodeChild, Tag,
+    Attr, Element, KebabIdent, KebabIdentOrStr, NodeChild, Tag, Value,
 };
 
 /// Functions for specific parts of an element's expansion.
@@ -168,87 +168,80 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
 
     // attribute methods to add when building
     let mut attrs = TokenStream::new();
-    let mut dyn_attrs: Vec<&Directive> = Vec::new();
-    let mut use_directives: Vec<&Directive> = Vec::new();
+    let mut directive_paths: Vec<TokenStream> = Vec::new();
     // the variables (idents) to clone before making children
     // in the form `let name = name.clone();`
     let mut clones = TokenStream::new();
-    let mut event_listeners = TokenStream::new();
-    // components can take `.some-class` or `class:this={signal}` by passing it into
-    // the `class` prop
-    // .0 is the class string, .1 is the 'signal' (or `None` if using selectors)
-    let mut dyn_classes: Vec<(KebabIdentOrStr, Option<TokenStream>)> = Vec::new();
-    let mut classes_span: Option<Span> = None;
-    // ids are not reactive (no `id:this={signal}`), will just be from selectors
-    let mut selector_ids: Vec<KebabIdent> = Vec::new();
-    let mut id_span: Option<Span> = None;
 
-    let mut spread_attrs = TokenStream::new();
-
-    for sel in element.selectors().iter() {
-        match sel {
-            SelectorShorthand::Id { id, pound_symbol } => {
-                selector_ids.push(id.clone());
-                id_span.get_or_insert(pound_symbol.span);
-            }
-            SelectorShorthand::Class { class, dot_symbol } => {
-                dyn_classes.push((KebabIdentOrStr::KebabIdent(class.clone()), None));
-                classes_span.get_or_insert(dot_symbol.span);
-            }
-        };
+    {
+        // all the ids need to be collected together
+        // as multiple attr:id=... creates multiple `id=...` attributes on teh element
+        let mut ids = Vec::<KebabIdent>::new();
+        let mut first_pound_symbol = None;
+        for sel in element.selectors().iter() {
+            match sel {
+                SelectorShorthand::Id { id, pound_symbol } => {
+                    first_pound_symbol.get_or_insert(*pound_symbol);
+                    ids.push(id.clone());
+                }
+                SelectorShorthand::Class { class, dot_symbol } => {
+                    // desugar to class:the-class
+                    directive_paths.push(
+                        directive_to_any_attr_path(&Directive {
+                            dir: syn::Ident::new("class", dot_symbol.span),
+                            key: KebabIdentOrStr::KebabIdent(class.clone()),
+                            modifier: None,
+                            value: None,
+                        })
+                        .expect("class directive is known"),
+                    );
+                }
+            };
+        }
+        // push all the ids as directive
+        if let Some(first_pound_symbol) = first_pound_symbol {
+            let joined_ids = ids
+                .iter()
+                .map(|ident| ident.repr())
+                .collect::<Vec<_>>()
+                .join(" ");
+            // desugar to attr:id="the-id id2 id3"
+            directive_paths.push(
+                directive_to_any_attr_path(&Directive {
+                    dir: syn::Ident::new("attr", Span::call_site()),
+                    key: parse_quote_spanned! { first_pound_symbol.span=> id },
+                    modifier: None,
+                    value: Some(Value::Lit(parse_quote!(#joined_ids))),
+                })
+                .expect("attr directive is known"),
+            );
+        }
     }
-
     element.attrs().iter().for_each(|a| match a {
         Attr::Kv(attr) => attrs.extend(component_kv_attribute_tokens(attr)),
         Attr::Spread(spread) => {
             if IS_SLOT {
                 emit_error!(spread.span(), "spread syntax is not supported on slots");
             } else {
-                spread_attrs.extend(component_spread_tokens(spread));
+                directive_paths.push(component_spread_tokens(spread));
             }
         }
         Attr::Directive(dir) => match dir.dir.to_string().as_str() {
-            "on" => {
-                if IS_SLOT {
-                    emit_error!(dir.dir.span(), "`on:` is not supported on slots");
-                } else {
-                    event_listeners.extend(event_listener_tokens(dir));
-                }
-            }
-            "attr" => {
-                if IS_SLOT {
-                    emit_error!(dir.dir.span(), "`attr:` is not supported on slots");
-                } else {
-                    emit_error_if_modifier(dir.modifier.as_ref());
-                    dyn_attrs.push(dir);
-                }
-            }
-            "use" => {
-                if IS_SLOT {
-                    emit_error!(dir.dir.span(), "`use:` is not supported on slots");
-                } else {
-                    emit_error_if_modifier(dir.modifier.as_ref());
-                    use_directives.push(dir);
-                }
-            }
+            // clone works on both components and slots
             "clone" => {
                 emit_error_if_modifier(dir.modifier.as_ref());
                 clones.extend(component_clone_tokens(dir));
             }
-            "class" => {
-                emit_error_if_modifier(dir.modifier.as_ref());
-                dyn_classes.push((dir.key.clone(), Some(dir.value.to_token_stream())));
-                classes_span.get_or_insert(dir.dir.span());
-            }
-            "style" | "prop" => {
-                emit_error!(
-                    dir.dir.span(),
-                    "`{}:` is not supported on components/slots",
-                    dir.dir
-                );
+            // slots support no other directives
+            other if IS_SLOT => {
+                emit_error!(dir.dir.span(), "`{}:` is not supported on slots", other);
             }
             _ => {
-                emit_error!(dir.dir.span(), "unknown directive");
+                if let Some(path) = directive_to_any_attr_path(dir) {
+                    directive_paths.push(path);
+                } else {
+                    emit_error!(dir.dir.span(), "unknown directive");
+                }
             }
         },
     });
@@ -268,27 +261,23 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
         .children()
         .map(|children| slots_to_tokens(children.slot_children()));
 
-    let dyn_attrs = component_dyn_attrs_to_methods(&dyn_attrs);
-    let use_directives = use_directives.into_iter().map(use_directive_to_method);
-    let dyn_classes = component_classes_to_method(dyn_classes, classes_span);
-    let selector_ids = component_ids_to_method(selector_ids, id_span);
-
     // if attributes are missing, an error is made in `.build()` by the component
     // builder.
     let build = quote_spanned!(path.span()=> .build());
 
     if IS_SLOT {
+        todo!()
         // Into is for turning a single slot into a vec![slot] if needed
-        Some(quote! {
-            ::std::convert::Into::into(
-                #path::builder()
-                    #attrs
-                    #dyn_classes
-                    #selector_ids
-                    #children
-                    #build
-            )
-        })
+        // Some(quote! {
+        //     ::std::convert::Into::into(
+        //         #path::builder()
+        //             #attrs
+        //             #dyn_classes
+        //             #selector_ids
+        //             #children
+        //             #build
+        //     )
+        // })
     } else {
         // this whole thing needs to be spanned to avoid errors occurring at the whole
         // call site.
@@ -305,17 +294,14 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
                     &#path,
                     #component_props_builder
                         #attrs
-                        #dyn_classes
-                        #selector_ids
                         #children
                         #slot_children
                         #build
-                        #dyn_attrs
-                        #spread_attrs
                 )
+                .add_any_attr((
+                    #(#directive_paths,)*
+                ))
             )
-            #(#use_directives)*
-            #event_listeners
         })
     }
 }

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{ext::IdentExt, spanned::Spanned};
 

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -49,7 +49,7 @@ pub fn children_fragment_tokens<'a>(
 ) -> TokenStream {
     quote_spanned! { span=>
         ::leptos::prelude::View::new((
-            #( #children ),*
+            #( #children, )*
         ))
     }
 }
@@ -293,15 +293,15 @@ pub fn component_to_tokens<const IS_SLOT: bool>(element: &Element) -> Option<Tok
         // this whole thing needs to be spanned to avoid errors occurring at the whole
         // call site.
         let component_props_builder = quote_spanned! {
-            path.span()=> ::leptos::component_props_builder(&#path)
+            path.span()=> ::leptos::component::component_props_builder(&#path)
         };
 
         Some(quote! {
             // the .build() returns `!` if not all props are present.
             // this causes unreachable code warning in ::leptos::component_view
             #[allow(unreachable_code)]
-            ::leptos::IntoView::into_view(
-                ::leptos::component_view(
+            ::leptos::prelude::View::new(
+                ::leptos::component::component_view(
                     &#path,
                     #component_props_builder
                         #attrs

--- a/leptos-mview-core/src/expand.rs
+++ b/leptos-mview-core/src/expand.rs
@@ -60,7 +60,7 @@ pub fn children_fragment_tokens<'a>(
 ///
 /// # Example
 /// ```ignore
-/// use leptos::*;
+/// use leptos::prelude::*;
 /// use leptos_mview::mview;
 /// let div = create_node_ref::<html::Div>();
 /// mview! {

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -169,7 +169,7 @@ pub(super) fn xml_directive_tokens(directive: &Directive) -> TokenStream {
 
 pub(super) fn xml_spread_tokens(attr: &SpreadAttr) -> TokenStream {
     let (dotdot, expr) = (attr.dotdot(), attr.expr());
-    let attrs = syn::Ident::new("attrs", dotdot.span());
+    let attrs = syn::Ident::new("add_any_attr", dotdot.span());
     quote! {
         .#attrs(#expr)
     }

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -280,7 +280,7 @@ pub(super) fn component_children_tokens<'a>(
         // given a regular `ChildrenFn` instead.
         let closure = quote_spanned!(child_span=> move || #children_fragment);
         quote! {
-            ::leptos::ToChildren::to_children(#closure)
+            ::leptos::children::ToChildren::to_children(#closure)
         }
     };
 

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::emit_error;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
+use syn::{ext::IdentExt, spanned::Spanned};
 
 use crate::{
     ast::{
@@ -11,27 +11,24 @@ use crate::{
             selector::{SelectorShorthand, SelectorShorthands},
             spread_attrs::SpreadAttr,
         },
-        KebabIdent, KebabIdentOrStr, NodeChild, TagKind,
+        KebabIdentOrStr, NodeChild, TagKind, Value,
     },
     expand::{children_fragment_tokens, emit_error_if_modifier},
-    span,
 };
 
 ////////////////////////////////////////////////////////////////
 // ------------------- shared subroutines ------------------- //
 ////////////////////////////////////////////////////////////////
 
-/// Converts a `use:directive={value}` to a method.
-///
-/// The expansion for components and xml elements are the same.
+/// Converts a `use:directive={value}` to a key (function) and value.
 ///
 /// ```text
-/// use:d => .directive(d, ().into())
-/// use:d={some_value} => .directive(d, some_value.into())
+/// use:d => (d, ().into())
+/// use:d={some_value} => (d, some_value.into())
 /// ```
 ///
 /// **Panics** if the provided directive is not `use:`.
-pub(super) fn use_directive_to_method(u: &Directive) -> TokenStream {
+pub(super) fn use_directive_fn_value(u: &Directive) -> (syn::Ident, TokenStream) {
     let Directive {
         dir: use_token,
         key,
@@ -42,20 +39,19 @@ pub(super) fn use_directive_to_method(u: &Directive) -> TokenStream {
     let directive_fn = key.to_ident_or_emit();
     emit_error_if_modifier(modifier.as_ref());
 
-    let directive = syn::Ident::new("directive", use_token.span());
     let value = value.as_ref().map_or_else(
         || quote_spanned! {directive_fn.span()=> ().into() },
         |val| quote! { ::std::convert::Into::into(#val) },
     );
-    quote! { .#directive(#directive_fn, #value) }
+    (directive_fn, value)
 }
 
-pub(super) fn event_listener_tokens(dir: &Directive) -> TokenStream {
+pub(super) fn event_listener_event_path(dir: &Directive) -> TokenStream {
     let Directive {
         dir,
         key,
         modifier,
-        value,
+        value: _,
     } = dir;
     assert_eq!(dir, "on", "directive should be `on:`");
 
@@ -67,20 +63,57 @@ pub(super) fn event_listener_tokens(dir: &Directive) -> TokenStream {
         }
     };
 
-    let event = if let Some(modifier) = modifier {
+    if let Some(modifier) = modifier {
         if modifier == "undelegated" {
-            quote! { ::leptos::ev::#modifier(::leptos::ev::#ev_name) }
+            quote! {
+                ::leptos::tachys::html::event::#modifier(
+                    ::leptos::tachys::html::event::#ev_name
+                )
+            }
         } else {
             emit_error!(
                 modifier.span(), "unknown modifier";
                 help = ":undelegated is the only known modifier"
             );
-            quote! { ::leptos::ev::#ev_name }
+            quote! { ::leptos::tachys::html::event::#ev_name }
         }
     } else {
-        quote! { ::leptos::ev::#ev_name }
-    };
-    quote! { .#dir(#event, #value) }
+        quote! { ::leptos::tachys::html::event::#ev_name }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttributeKind {
+    /// "class"
+    Class,
+    /// "style"
+    Style,
+    /// An attribute with a `-`, like data-*
+    ///
+    /// Excludes `aria-*` attributes.
+    Custom,
+    /// An attribute that should be added by a method so that it is checked.
+    OtherChecked,
+}
+
+impl AttributeKind {
+    pub fn is_custom(self) -> bool { self == Self::Custom }
+
+    pub fn is_class_or_style(self) -> bool { matches!(self, Self::Class | Self::Style) }
+}
+
+impl From<&str> for AttributeKind {
+    fn from(value: &str) -> Self {
+        if value == "class" {
+            Self::Class
+        } else if value == "style" {
+            Self::Style
+        } else if value.contains('-') && !value.starts_with("aria-") {
+            Self::Custom
+        } else {
+            Self::OtherChecked
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////
@@ -122,20 +155,19 @@ pub(super) fn xml_kv_attribute_tokens(attr: &KvAttr, element_tag: TagKind) -> To
         // - it's not `class` nor `style`, and
         // - It's a custom web component or SVG element
         // - or it's a custom or data attribute (has `-` except for `aria-`)
-        let is_class_or_style = ["class", "style"].contains(&key.repr());
+        let attr_kind = AttributeKind::from(key.repr());
         let is_web_or_svg = matches!(element_tag, TagKind::Svg | TagKind::WebComponent);
-        let is_custom_attribute = key.repr().contains('-') && !key.repr().starts_with("aria-");
 
-        if is_class_or_style || !(is_web_or_svg || is_custom_attribute) {
-            // checked attribute
-            let key = key.to_snake_ident();
-            quote! { .#key(#value) }
-        } else {
+        if (is_web_or_svg || attr_kind.is_custom()) && !attr_kind.is_class_or_style() {
             // unchecked attribute
             // don't span the attribute to the string, unnecessary and makes it
             // string-colored
             let key = key.repr();
             quote! { .attr(#key, ::leptos::prelude::IntoAttributeValue::into_attribute_value(#value)) }
+        } else {
+            // checked attribute
+            let key = key.to_snake_ident();
+            quote! { .#key(#value) }
         }
     }
 }
@@ -154,8 +186,17 @@ pub(super) fn xml_directive_tokens(directive: &Directive) -> TokenStream {
             emit_error_if_modifier(modifier.as_ref());
             quote! { .#dir((#key, #value)) }
         }
-        "on" => event_listener_tokens(directive),
-        "use" => use_directive_to_method(directive),
+        "on" => {
+            let event_path = event_listener_event_path(directive);
+            quote! { .#dir(#event_path, #value) }
+        }
+        "use" => {
+            let (fn_name, value) = use_directive_fn_value(directive);
+            let directive = syn::Ident::new("directive", dir.span());
+            quote! {
+                .#directive(#fn_name, #value)
+            }
+        }
         "attr" | "clone" => {
             emit_error!(dir.span(), "`{}:` is not supported on elements", dir);
             quote! {}
@@ -294,172 +335,107 @@ pub(super) fn component_children_tokens<'a>(
     }
 }
 
-pub(super) fn component_dyn_attrs_to_methods(dyn_attrs: &[&Directive]) -> Option<TokenStream> {
-    // expand dyn attrs to the method if any exist
-    if dyn_attrs.is_empty() {
-        return None;
-    };
+// https://github.com/leptos-rs/leptos/blob/5947aa299e5299eb3dc75c58e28affb15e79b6ff/leptos_macro/src/view/mod.rs#L998
 
-    let dyn_attrs_method = syn::Ident::new("dyn_attrs", dyn_attrs[0].dir.span());
-
-    let (keys, values): (Vec<_>, Vec<_>) = dyn_attrs
-        .iter()
-        .map(|a| (a.key.to_lit_str(), &a.value))
-        .unzip();
-
-    Some(quote! {
-        .#dyn_attrs_method(
-            <[_]>::into_vec(std::boxed::Box::new([
-                #( (#keys, ::leptos::IntoAttribute::into_attribute(#values)) ),*
-            ]))
-        )
-    })
-}
-
-pub(super) fn component_spread_tokens(attr: &SpreadAttr) -> TokenStream {
-    let (dotdot, expr) = (attr.dotdot(), attr.expr());
-    let dyn_bindings = syn::Ident::new("dyn_bindings", dotdot.span());
-    quote! {
-        .#dyn_bindings(#expr)
-    }
-}
-
-// special attributes on components that add to a special set of props //
-
-/// Adds potentially reactive classes to the `class` attribute of a component.
+/// Converts a directive on a component to a path to be used on
+/// `.add_any_attr(...)`
 ///
-/// If no classes are reactive, a static string will be passed in. Otherwise,
-/// the string is constructed and updated at runtime, which may have performance
-/// drawbacks as the entire prop is updated if one signal changes.
+/// Returns [`None`] if the directive is an unknown directive, or `clone`.
 ///
-/// The intended use is as follows:
+/// Adding these directives to a component looks like:
 /// ```ignore
-/// #[component]
-/// fn TakesClasses(#[prop(optional, into)] class: TextProp) -> impl IntoView {}
-///
-/// let signal = RwSignal::new(true);
-///
-/// mview! {
-///     TakesClasses.class-1.another-class class:reactive={signal};
-/// }
+/// View::new(
+///     leptos::component::component_view(.., ..)
+///     .add_any_attr((
+///         leptos::tachys::html::class::class("something"),
+///         leptos::tachys::html::class::class(("conditional", true)),
+///         leptos::tachys::html::style::style(("position", "absolute")),
+///         leptos::tachys::html::attribute::contenteditable(true),
+///         leptos::tachys::html::attribute::custom::custom_attribute("data-index", 0),
+///         leptos::tachys::html::property::prop("value", "aaaa"),
+///         leptos::tachys::html::event::on(
+///             leptos::tachys::html::event::undelegated(
+///                 leptos::tachys::html::event::click
+///             ),
+///             || ()
+///         ),
+///         leptos::tachys::html::directive::directive(directive_name, ().into())
+///     ))
+/// )
 /// ```
-///
-/// For now, what is passed in to `{signal}` must be something that impls `Fn()
-/// -> bool`, it cannot just be a `bool`.
-///
-/// Returns [`None`] if `class_span` is [`None`] or `classes` is empty.
-pub(super) fn component_classes_to_method(
-    classes: Vec<(KebabIdentOrStr, Option<TokenStream>)>,
-    class_span: Option<Span>,
-) -> Option<TokenStream> {
-    let Some(class_span) = class_span else { return None };
-    if classes.is_empty() {
-        return None;
-    };
-
-    fn generate_dummy_assignments(
-        idents: impl IntoIterator<Item = (KebabIdentOrStr, Option<TokenStream>)>,
-    ) -> impl Iterator<Item = TokenStream> {
-        idents
-            .into_iter()
-            .filter_map(|(maybe_ident, _)| match maybe_ident {
-                KebabIdentOrStr::KebabIdent(ident) => {
-                    Some(span::color_all(ident.spans()).collect::<TokenStream>())
-                }
-                KebabIdentOrStr::Str(_) => None,
-            })
-    }
-
-    // if there are no reactive classes, just create the string
-    if classes.iter().all(|(_, signal)| signal.is_none()) {
-        let string = classes
-            .iter()
-            .map(|(class, _)| class.to_lit_str().value())
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        let dummy_assignments = generate_dummy_assignments(classes);
-
-        let class = quote_spanned!(class_span=> class);
-        Some(quote!(.#class({
-            #(#dummy_assignments)*
-            #string
-        })))
-    } else {
-        // there are reactive classes: need to construct it at runtime
-
-        // TODO: is there a way to accept both `bool` and `Fn() -> bool`?
-        // maybe `leptos::Class`?
-
-        let classes_array = {
-            let classes_iter = classes.iter().map(|(class, signal)| {
-                let class_str = class.to_lit_str();
-                let bool_signal = match signal {
-                    Some(signal) => {
-                        // add extra bracket to make sure the closure is called
-                        quote_spanned!(signal.span()=> (#signal)())
+pub(super) fn directive_to_any_attr_path(directive: &Directive) -> Option<TokenStream> {
+    let dir = &directive.dir;
+    let path = match &*dir.to_string() {
+        "class" | "style" => {
+            // avoid making it string coloured
+            let key = directive.key.to_unspanned_string();
+            let value = directive.value.clone().unwrap_or_else(Value::new_true);
+            // to avoid spanning the directive to the module
+            let dir_unspanned = syn::Ident::new(&dir.to_string(), Span::call_site());
+            quote! {
+                ::leptos::tachys::html::#dir_unspanned::#dir((#key, #value))
+            }
+        }
+        "attr" => {
+            let attr_kind = AttributeKind::from(&*directive.key.to_lit_str().value());
+            match attr_kind {
+                AttributeKind::Class | AttributeKind::Style => {
+                    let class_or_style = directive.key.to_ident_or_emit();
+                    let value = directive.value.clone().unwrap_or_else(Value::new_true);
+                    // to avoid spanning to the module name
+                    let class_or_style_unspanned =
+                        syn::Ident::new(&class_or_style.unraw().to_string(), Span::call_site());
+                    quote! {
+                        ::leptos::tachys::html::#class_or_style_unspanned::#class_or_style(#value)
                     }
-                    None => quote!(true),
-                };
-
-                // use fully qualified path so that error says 'incorrect type' instead of
-                // 'method `then_some` not found'
-                quote_spanned! { bool_signal.span()=>
-                    ::std::primitive::bool::then_some(#bool_signal, #class_str)
                 }
-            });
-
-            quote_spanned!(class_span=> [#(#classes_iter),*])
-        };
-        let contents = quote_spanned! { class_span=>
-            #classes_array
-                .iter()
-                .flatten() // remove None
-                .cloned() // turn &&str to &str
-                .collect::<Vec<&str>>()
-                .join(" ")
-        };
-
-        let dummy_assignments = generate_dummy_assignments(classes);
-
-        let class = quote_spanned!(class_span=> class);
-        Some(quote! {
-            .#class(move || {
-                #(#dummy_assignments)*
-                #contents
-            })
-        })
-    }
-}
-
-/// Adds a list of strings to the `id` prop of a component.
-///
-/// IDs should not be changed reactively, so it is not supported.
-///
-/// Returns [`None`] if `id_span` is [`None`] or `ids` is empty.
-pub(super) fn component_ids_to_method(
-    ids: Vec<KebabIdent>,
-    id_span: Option<Span>,
-) -> Option<TokenStream> {
-    let id_span = id_span?;
-    if ids.is_empty() {
-        return None;
+                AttributeKind::Custom => {
+                    let attr_name = directive.key.to_unspanned_string();
+                    let value = directive.value.clone().unwrap_or_else(Value::new_true);
+                    quote! {
+                        ::leptos::tachys::html::attribute::custom::custom_attribute(#attr_name, #value)
+                    }
+                }
+                AttributeKind::OtherChecked => {
+                    let attr_name = directive.key.to_ident_or_emit();
+                    let value = directive.value.clone().unwrap_or_else(Value::new_true);
+                    quote! {
+                        ::leptos::tachys::html::attribute::#attr_name(#value)
+                    }
+                }
+            }
+        }
+        "prop" => {
+            let prop = directive.key.to_ident_or_emit();
+            let value = directive.value.clone().unwrap_or_else(Value::new_true);
+            quote! {
+                ::leptos::tachys::html::property::#prop(#value)
+            }
+        }
+        "on" => {
+            let event_path = event_listener_event_path(directive);
+            let value = &directive.value;
+            quote! {
+                ::leptos::tachys::html::event::on(#event_path, #value)
+            }
+        }
+        "use" => {
+            let (fn_name, value) = use_directive_fn_value(directive);
+            let directive_method = syn::Ident::new("directive", directive.dir.span());
+            quote! {
+                ::leptos::tachys::html::directive::#directive_method(
+                    #fn_name,
+                    #value
+                )
+            }
+        }
+        _ => return None,
     };
 
-    // ids are not reactive, so just give one big string
-    let id_str = ids
-        .iter()
-        .map(|id| id.to_lit_str().value())
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    let dummy_assignments = ids
-        .into_iter()
-        .map(|ident| span::color_all(ident.spans()).collect::<TokenStream>());
-
-    let id = quote_spanned!(id_span=> id);
-    Some(quote!(.#id({
-        #(#dummy_assignments)*
-        #id_str
-    })))
+    Some(path)
 }
+
+/// This should be added with all the other directives.
+///
+/// Spread attrs are added as `.add_any_attr(expr)`.
+pub(super) fn component_spread_tokens(attr: &SpreadAttr) -> TokenStream { attr.expr().clone() }

--- a/leptos-mview-core/src/expand/subroutines.rs
+++ b/leptos-mview-core/src/expand/subroutines.rs
@@ -181,10 +181,15 @@ pub(super) fn xml_directive_tokens(directive: &Directive) -> TokenStream {
     } = directive;
 
     match dir.to_string().as_str() {
-        "class" | "style" | "prop" => {
+        "class" | "style" => {
             let key = key.to_lit_str();
             emit_error_if_modifier(modifier.as_ref());
             quote! { .#dir((#key, #value)) }
+        }
+        "prop" => {
+            let key = key.to_lit_str();
+            emit_error_if_modifier(modifier.as_ref());
+            quote! { .#dir(#key, #value) }
         }
         "on" => {
             let event_path = event_listener_event_path(directive);

--- a/leptos-mview-core/src/expand/utils.rs
+++ b/leptos-mview-core/src/expand/utils.rs
@@ -1,4 +1,4 @@
-use proc_macro_error::{abort, emit_error};
+use proc_macro_error2::{abort, emit_error};
 use syn::{parse_quote, spanned::Spanned};
 
 #[allow(clippy::doc_markdown)]

--- a/leptos-mview-core/src/lib.rs
+++ b/leptos-mview-core/src/lib.rs
@@ -14,7 +14,7 @@ mod span;
 
 use ast::Child;
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::quote;
 use syn::spanned::Spanned;
 
@@ -24,7 +24,7 @@ use crate::{ast::Children, expand::children_fragment_tokens};
 pub fn mview_impl(input: TokenStream) -> TokenStream {
     // return () in case of any errors, to avoid "unexpected end of macro
     // invocation" e.g. when assigning `let res = mview! { ... };`
-    proc_macro_error::set_dummy(quote! { () });
+    proc_macro_error2::set_dummy(quote! { () });
 
     let children = match syn::parse2::<Children>(input) {
         Ok(tree) => tree,

--- a/leptos-mview-macro/Cargo.toml
+++ b/leptos-mview-macro/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 proc-macro2 = "1"
 proc-macro-error2 = "2"
 leptos-mview-core = { path = "../leptos-mview-core", version = "0.3.2" }
+
+[features]
+nightly = ["proc-macro-error2/nightly"]

--- a/leptos-mview-macro/Cargo.toml
+++ b/leptos-mview-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-mview-macro"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Proc macro export for leptos-mview"
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 proc-macro-error2 = "2"
-leptos-mview-core = { path = "../leptos-mview-core", version = "0.3.2" }
+leptos-mview-core = { path = "../leptos-mview-core", version = "0.4.0" }
 
 [features]
 nightly = ["proc-macro-error2/nightly"]

--- a/leptos-mview-macro/Cargo.toml
+++ b/leptos-mview-macro/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-proc-macro-error = { version = "1", default-features = false }
+proc-macro-error2 = "2"
 leptos-mview-core = { path = "../leptos-mview-core", version = "0.3.2" }

--- a/leptos-mview-macro/src/lib.rs
+++ b/leptos-mview-macro/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 
 #[proc_macro_error]
 #[proc_macro]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ The below are the versions with which I have tested it to be working. It is like
 | `0.1`                  | `0.5`                       |
 | `0.2`                  | `0.5`, `0.6`                |
 | `0.3`                  | `0.6`                       |
+| `0.4`                  | `0.7`                       |
+
+This crate also has a feature `"nightly"` that enables better proc-macro diagnostics (simply enables the nightly feature in proc-macro-error2. Necessary while [this pr](https://github.com/GnomedDev/proc-macro-error-2/pull/5) is not yet merged).
 
 # Syntax details
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ An alternative `view!` macro for [Leptos](https://github.com/leptos-rs/leptos/tr
 A little preview of the syntax:
 
 ```
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]
@@ -49,7 +49,7 @@ async fn fetch_from_db(data: String) -> usize { data.len() }
 <summary> Explanation of the example: </summary>
 
 ```
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]
@@ -134,7 +134,7 @@ Elements have the following structure:
 
 Example:
 ```
-# use leptos_mview::mview; use leptos::*;
+# use leptos_mview::mview; use leptos::prelude::*;
 # let handle_input = |_| ();
 # #[component] fn MyComponent(data: i32, other: &'static str) -> impl IntoView {}
 mview! {
@@ -147,7 +147,7 @@ mview! {
 
 Adding generics is the same as in Leptos: add it directly after the component name, with or without the turbofish.
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 # use core::marker::PhantomData;
 #[component]
 pub fn GenericComponent<S>(ty: PhantomData<S>) -> impl IntoView {
@@ -185,7 +185,7 @@ The name of the parameter in the component function must be the same as the slot
 
 Using the slots defined by the [`SlotIf` example linked](https://github.com/leptos-rs/leptos/blob/main/examples/slots/src/lib.rs):
 ```
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 
 #[component]
@@ -268,7 +268,7 @@ There are (currently) 3 main types of values you can pass in:
 
 - Values wrapped in **brackets** (like `value=[a_bool().to_string()]`) are shortcuts for a block with an empty closure `move || ...` (to `value={move || a_bool().to_string()}`).
     ```rust
-    # use leptos::*; use leptos_mview::mview;
+    # use leptos::prelude::*; use leptos_mview::mview;
     # let number = || 3;
     mview! {
         Show
@@ -321,7 +321,7 @@ Most attributes are `key=value` pairs. The `value` follows the rules from above.
 
         Can be used elsewhere like this:
         ```
-        # use leptos::*; use leptos_mview::mview;
+        # use leptos::prelude::*; use leptos_mview::mview;
         # #[component] fn Something(some_attribute: i32) -> impl IntoView {}
         mview! { Something some-attribute=5; }
         # ;
@@ -348,7 +348,7 @@ Note that the special `node_ref` or `ref` or `_ref` or `ref_` attribute in Lepto
 
 Another shortcut is that boolean attributes can be written without adding `=true`. Watch out though! `checked` is **very different** to `{checked}`.
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 // recommend usually adding #[prop(optional)] to all these
 #[component]
 fn LotsOfFlags(wide: bool, tall: bool, red: bool, curvy: bool, count: i32) -> impl IntoView {}
@@ -375,7 +375,7 @@ Some special attributes (distinguished by the `:`) called **directives** have sp
 
 All of these directives except `clone` also support the attribute shorthand:
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 let color = create_rw_signal("red".to_string());
 let disabled = false;
 mview! {
@@ -386,7 +386,7 @@ mview! {
 
 The `class` and `style` directives also support using string literals, for more complicated names. Make sure the string for `class:` doesn't have spaces, or it will panic!
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 let yes = move || true;
 mview! {
     div class:"complex-[class]-name"={yes}
@@ -404,7 +404,7 @@ There are a few special attributes you can put on your component to emulate some
 If a component has a `class` attribute, the classes using the selector syntax `.some-class` and dynamic classes `class:thing={signal}` can be passed in!
 
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 #[component]
 // the `class` parameter should have these attributes and type to work properly
 fn TakesClasses(#[prop(optional, into)] class: TextProp) -> impl IntoView {
@@ -436,7 +436,7 @@ There is one small difference from the `class:` syntax on HTML elements: the val
 
 This is also supported with an `id` attribute to forward `#my-id`, though not reactively.
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 #[component]
 // the `id` parameter should have these attributes and type to work properly
 fn TakesIds(#[prop(optional)] id: &'static str) -> impl IntoView {
@@ -459,7 +459,7 @@ You may have noticed that the `let:data` prop was missing from the previous sect
 
 This is replaced with a closure right before the children block. This way, you can pass in multiple arguments to the children more easily.
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 mview! {
     Await
         future=[async { 3 }]
@@ -474,7 +474,7 @@ Note that you will usually need to add a `*` before the data you are using. If y
 
 Children can be wrapped in either braces or parentheses, whichever you prefer.
 ```
-# use leptos::*; use leptos_mview::mview;
+# use leptos::prelude::*; use leptos_mview::mview;
 mview! {
     p {
         "my " strong("bold") " and " em("fancy") " text."
@@ -494,7 +494,7 @@ Children with closures are also supported on slots, add a field `children: Callb
 If an attribute shorthand has hyphens:
 - On components, both the key and value will be converted to underscores.
     ```
-    # use leptos::*; use leptos_mview::mview;
+    # use leptos::prelude::*; use leptos_mview::mview;
     # #[component] fn Something(some_attribute: i32) -> impl IntoView {}
     let some_attribute = 5;
     mview! { Something {some-attribute}; }
@@ -530,7 +530,7 @@ Becomes `<input type="checkbox" checked data-smth />`, NOT `checked="true"` or `
 
 To have the attribute have a value of the string "true" or "false", use `.to_string()` on the bool. Make sure that it's in a closure if you're working with signals too.
 ```
-# use leptos::*;
+# use leptos::prelude::*;
 # use leptos_mview::mview;
 let boolean_signal = RwSignal::new(true);
 mview! { input type="checkbox" checked=[boolean_signal().to_string()]; }

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -1,4 +1,4 @@
-use leptos::{prelude::*, task::Executor, text_prop::TextProp};
+use leptos::{prelude::*, task::Executor};
 use leptos_mview::mview;
 mod utils;
 use utils::check_str;
@@ -138,18 +138,18 @@ fn let_patterns() {
 }
 
 #[component]
-fn TakesClass(#[prop(into)] class: TextProp) -> impl IntoView {
+fn TakesClass() -> impl IntoView {
     mview! {
-        div class=f["takes-class {}", class.get()] {
+        div class="takes-class" {
             "I take more classes!"
         }
     }
 }
 
 #[component]
-fn TakesIds(id: &'static str) -> impl IntoView {
+fn TakesIds() -> impl IntoView {
     mview! {
-        div {id} class="i-take-ids";
+        div class="i-take-ids";
     }
 }
 
@@ -172,7 +172,7 @@ fn class_dir() {
     };
     check_str(
         r,
-        r#"div class="takes-class test1 test-2 this complicated""#,
+        r#"div class="takes-class test1 test-2  this complicated""#,
     );
 }
 

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -109,7 +109,7 @@ fn qualified_paths() {
 
 // don't try parse slot:: as a slot
 mod slot {
-    use leptos::*;
+    use leptos::prelude::*;
 
     #[component]
     pub fn NotASlot() -> impl IntoView {}

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,4 +1,8 @@
-use leptos::*;
+use leptos::{
+    html::{self, HtmlElement},
+    prelude::*,
+    text_prop::TextProp,
+};
 use leptos_mview::mview;
 mod utils;
 use utils::check_str;
@@ -17,17 +21,17 @@ use utils::check_str;
 
 #[test]
 fn single_element() {
-    let result: HtmlElement<html::Div> = mview! {
+    let result: HtmlElement<html::Div, _, _> = mview! {
         div {
             "hi"
         }
     };
-    check_str(result, r#"<div data-hk="0-0-0-1">hi</div>"#);
+    check_str(result, r#"<div>hi</div>"#);
 }
 
 #[test]
 fn multi_element_is_fragment() {
-    let _fragment: Fragment = mview! {
+    let _fragment: View<_> = mview! {
         div { "a" }
         span { "b" }
     };
@@ -45,15 +49,19 @@ fn a_bunch() {
         input type="checkbox" checked;
     };
 
+    view! {
+        <span class="abc" style:a="b"></span>
+    };
+
     check_str(
         result,
         "hi\
-        <span class=\"abc\" data-index=\"0\" data-hk=\"0-0-0-2\">\
-            <strong data-hk=\"0-0-0-3\">d</strong>\
+        <span data-index=\"0\" class=\"abc\">\
+            <strong>d</strong>\
             3\
         </span>\
-        <br data-hk=\"0-0-0-4\"/>\
-        <input type=\"checkbox\" checked data-hk=\"0-0-0-5\"/>",
+        <br>\
+        <input type=\"checkbox\" checked>",
     );
 }
 
@@ -67,7 +75,7 @@ fn directive_before_attr() {
     let result = mview! {
         span style:color="black" style="font-size: 1em;";
     };
-    check_str(result, "font-size: 1em; color: black;");
+    check_str(result, "font-size: 1em;;color:black;");
 }
 
 #[test]
@@ -88,7 +96,7 @@ fn multiple_directives() {
 
     check_str(
         result,
-        r#"class="normal here also-here" style="line-height: 1.5; color: white; background-color: red;""#,
+        r#"class="normal here  also-here" style="line-height: 1.5;;color:white;background-color:red;""#,
     );
 }
 
@@ -104,7 +112,7 @@ fn string_directives() {
 
     check_str(
         result,
-        r#"class="complex[class]-name" style="doesn't-exist: black;""#,
+        r#"class="complex[class]-name" style="doesn't-exist:black;""#,
     )
 }
 
@@ -117,3 +125,23 @@ fn mixed_class_creation() {
 
     check_str(r, r#"class="some-class another-class always-here""#);
 }
+
+#[test]
+fn custom_web_component() {
+    let component = mview! {
+        iconify-icon icon="a" class="something" {
+            "b"
+        }
+    };
+
+    check_str(
+        component,
+        r#"<iconify-icon icon="a" class="something">b</iconify-icon>"#,
+    );
+}
+
+// #[test]
+// fn has_ref() {
+//     let node_ref = NodeRef::new();
+//     mview
+// }

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -7,13 +7,13 @@ use leptos_mview::mview;
 mod utils;
 use utils::check_str;
 
-// #[test]
-// fn strings() {
-//     let result: &str = mview! {
-//         "hello there!"
-//     };
-//     assert_eq!(result, "hello there!");
-// }
+#[test]
+fn strings() {
+    let result: &str = mview! {
+        "hello there!"
+    };
+    assert_eq!(result, "hello there!");
+}
 
 // cannot traverse the DOM as there is no browser
 // so I am testing in a way similar to
@@ -140,8 +140,10 @@ fn custom_web_component() {
     );
 }
 
-// #[test]
-// fn has_ref() {
-//     let node_ref = NodeRef::new();
-//     mview
-// }
+#[test]
+fn has_ref() {
+    let node_ref = NodeRef::new();
+    mview! {
+        div ref={node_ref};
+    };
+}

--- a/tests/paren_children.rs
+++ b/tests/paren_children.rs
@@ -1,6 +1,6 @@
 //! Test allowing parentheses to wrap the children as well.
 
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 mod utils;
 use utils::check_str;

--- a/tests/spread.rs
+++ b/tests/spread.rs
@@ -1,32 +1,28 @@
-use leptos::*;
+use leptos::prelude::*;
 use leptos_mview::mview;
 mod utils;
 use utils::check_str;
 
 #[test]
 fn spread_html_element() {
-    let attrs: Vec<(&'static str, Attribute)> = vec![
-        ("a", "b".into_attribute()),
-        ("data-index", 0.into_attribute()),
-        ("class", "c".into_attribute()),
-    ];
+    let attrs = view! { <{..} data-index=0 class="c" data-another="b" /> };
     let res = mview! {
-        div {..attrs} class="b" {
+        div {..attrs} data-yet-another-thing="z" {
             "children"
         }
     };
     check_str(
         res,
-        r#"<div class="b" a="b" data-index="0" class="c" data-hk="0-0-0-1">children</div>"#,
+        r#"<div data-yet-another-thing="z" data-index="0" data-another="b" class="c">children</div>"#,
     );
 }
 
 #[test]
 fn spread_in_component() {
     #[component]
-    fn Spreadable(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
+    fn Spreadable() -> impl IntoView {
         mview! {
-            div {..attrs};
+            div;
         }
     }
 
@@ -35,30 +31,26 @@ fn spread_in_component() {
     };
     check_str(
         res,
-        r#"<div class="b" contenteditable data-index="0" data-hk="0-0-0-2"></div>"#,
+        r#"<div contenteditable data-index="0" class="b"></div>"#,
     );
 }
 
 #[test]
 fn spread_on_component() {
     #[component]
-    fn Spreadable(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
+    fn Spreadable() -> impl IntoView {
         mview! {
-            div {..attrs};
+            div;
         }
     }
 
-    let attrs: Vec<(&'static str, Attribute)> = vec![
-        ("a", "b".into_attribute()),
-        ("data-index", 0.into_attribute()),
-        ("class", "c".into_attribute()),
-    ];
+    let attrs = view! { <{..} data-a="b" data-index=0 class="c" /> };
 
     let res = mview! {
         Spreadable attr:contenteditable=true {..attrs};
     };
     check_str(
         res,
-        r#"<div contenteditable a="b" data-index="0" class="c" data-hk="0-0-0-2"></div>"#,
+        r#"<div contenteditable data-a="b" data-index="0" class="c"></div>"#,
     );
 }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,6 +1,13 @@
 #[test]
 fn ui() {
-    let t = trybuild::TestCases::new();
-    t.pass("tests/ui/pass/*.rs");
-    t.compile_fail("tests/ui/errors/*.rs");
+    // FIXME: diagnostics are unavoidably bad right now
+    // due to trait errors when there is an issue.
+    // these trait errors span the entire macro output,
+    // so there is no good way to scope errors to a specific span.
+    //
+    // not running any UI tests for now.
+
+    // let t = trybuild::TestCases::new();
+    // t.pass("tests/ui/pass/*.rs");
+    // t.compile_fail("tests/ui/errors/*.rs");
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-use leptos::*;
-use prelude::RenderHtml;
+use leptos::prelude::*;
 
 #[track_caller]
 pub fn check_str<'a>(component: impl IntoView, contains: impl Into<Contains<'a>>) {

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
 use leptos::*;
+use prelude::RenderHtml;
 
 #[track_caller]
 pub fn check_str<'a>(component: impl IntoView, contains: impl Into<Contains<'a>>) {
-    let component_str = component.into_view().render_to_string();
+    let component_str = component.into_view().to_html();
     match contains.into() {
         Contains::Str(s) => {
             assert!(

--- a/tests/values.rs
+++ b/tests/values.rs
@@ -1,3 +1,4 @@
+use leptos::prelude::*;
 use leptos_mview::mview;
 use utils::check_str;
 mod utils;


### PR DESCRIPTION
Released as 0.4.0. Completes #15 

A few unfortunate things:
- Error reporting has significantly degraded due to traits not being fulfilled. This makes the entire macro output become an error, so it is impossible for error reporting to be at reasonable spans. Most errors will show up for the entire macro call site.
- Now require `leptos::prelude::*` to be imported since attributes are checked and come from traits. It is possible to use a fully qualified trait path, but it may provide worse autocomplete. Better autocomplete at the cost of requiring the prelude to be imported seems to be a good trade off.
- nightly feature required for nightly diagnostics, as proc-macro-error2 does not automatically detect nightly.